### PR TITLE
fix: add missing 2FA password form in AuthWizard

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@tanstack/react-query": "^5.90.17",
         "@tanstack/react-virtual": "^3.13.18",
@@ -78,6 +78,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1823,6 +1824,7 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1925,6 +1927,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2560,6 +2563,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2587,6 +2591,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2608,6 +2613,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2617,6 +2623,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2810,6 +2817,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/app/src/components/AuthWizard.tsx
+++ b/app/src/components/AuthWizard.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { motion, AnimatePresence } from "framer-motion";
-import { Phone, Key, ArrowRight, Settings, ShieldCheck, Sun, Moon, HelpCircle, ExternalLink, X } from "lucide-react";
+import { Phone, Key, Lock, ArrowRight, Settings, ShieldCheck, Sun, Moon, HelpCircle, ExternalLink, X } from "lucide-react";
 import { load } from '@tauri-apps/plugin-store';
 import { useTheme } from '../context/ThemeContext';
 
@@ -52,6 +52,7 @@ export function AuthWizard({ onLogin }: { onLogin: () => void }) {
 
     const [phone, setPhone] = useState("");
     const [code, setCode] = useState("");
+    const [password, setPassword] = useState("");
     const [error, setError] = useState<string | null>(null);
     const [floodWait, setFloodWait] = useState<number | null>(null);
     const [showHelp, setShowHelp] = useState(false);
@@ -143,6 +144,7 @@ export function AuthWizard({ onLogin }: { onLogin: () => void }) {
     const handleCodeSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         setLoading(true);
+        setError(null);
         try {
             const res = await invoke<{ success: boolean; next_step?: string }>("cmd_auth_sign_in", { code });
             if (res.success) {
@@ -151,6 +153,24 @@ export function AuthWizard({ onLogin }: { onLogin: () => void }) {
                 setStep("password");
             } else {
                 setError("Unknown error");
+            }
+        } catch (err: unknown) {
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handlePasswordSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await invoke<{ success: boolean; next_step?: string }>("cmd_auth_check_password", { password });
+            if (res.success) {
+                onLogin();
+            } else {
+                setError("Password verification failed.");
             }
         } catch (err: unknown) {
             setError(err instanceof Error ? err.message : String(err));
@@ -342,6 +362,52 @@ export function AuthWizard({ onLogin }: { onLogin: () => void }) {
                                         </button>
                                         <button type="button" onClick={() => setStep("phone")} className="text-xs text-gray-500 hover:text-white transition-colors py-2">
                                             Change Phone Number
+                                        </button>
+                                    </div>
+                                </motion.form>
+                            )}
+
+
+                            {step === "password" && (
+                                <motion.form
+                                    key="password"
+                                    initial={{ x: 20, opacity: 0 }}
+                                    animate={{ x: 0, opacity: 1 }}
+                                    exit={{ x: -20, opacity: 0 }}
+                                    onSubmit={handlePasswordSubmit}
+                                    className="space-y-6"
+                                >
+                                    <div className="space-y-2">
+                                        <div className="p-3 bg-blue-500/10 border border-blue-500/20 rounded-xl mb-4">
+                                            <p className="text-xs text-blue-300 text-center">
+                                                Your account has Two-Factor Authentication enabled.
+                                                Please enter your cloud password to continue.
+                                            </p>
+                                        </div>
+                                        <label className="block text-xs font-semibold text-gray-400 uppercase tracking-wider">Cloud Password</label>
+                                        <div className="relative">
+                                            <Lock className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 auth-form-icon" />
+                                            <input
+                                                type="password"
+                                                value={password}
+                                                onChange={(e) => setPassword(e.target.value)}
+                                                placeholder="Enter your password"
+                                                className="w-full glass-input rounded-xl pl-12 pr-4 py-4 text-white placeholder-gray-600 focus:outline-none focus:border-blue-500 transition-all text-lg"
+                                                autoFocus
+                                            />
+                                        </div>
+                                    </div>
+
+                                    <div className="flex flex-col gap-3">
+                                        <button
+                                            type="submit"
+                                            disabled={loading || !password}
+                                            className="w-full bg-white text-black hover:bg-gray-100 font-bold py-4 rounded-xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed"
+                                        >
+                                            {loading ? "Verifying..." : "Unlock"}
+                                        </button>
+                                        <button type="button" onClick={() => { setStep("code"); setPassword(""); setError(null); }} className="text-xs text-gray-500 hover:text-white transition-colors py-2">
+                                            Back to Code Entry
                                         </button>
                                     </div>
                                 </motion.form>


### PR DESCRIPTION
The AuthWizard defined a 'password' step type but had no UI form for it. When users with Two-Factor Authentication entered their verification code, cmd_auth_sign_in returned next_step='password' but the app rendered a blank card since no form existed for that step.
I Added the complete password form with Lock icon, password input, handlePasswordSubmit calling cmd_auth_check_password, and error handling matching the existing design.