### PR TITLE
feat: add next/previous media preview navigation with lightweight caching and preview reliability fixes

### DIFF
--- a/app/src-tauri/src/commands/preview.rs
+++ b/app/src-tauri/src/commands/preview.rs
@@ -6,6 +6,41 @@ use crate::TelegramState;
 use crate::bandwidth::BandwidthManager;
 use crate::commands::utils::resolve_peer;
 
+const PREVIEW_CACHE_MAX_FILES: usize = 30;
+const PREVIEW_CACHE_MAX_TOTAL_BYTES: u64 = 80 * 1024 * 1024;
+
+fn prune_preview_cache(cache_dir: &std::path::Path) {
+    let read_dir = match std::fs::read_dir(cache_dir) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+
+    let mut files: Vec<(std::path::PathBuf, std::time::SystemTime, u64)> = Vec::new();
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if let Ok(meta) = entry.metadata() {
+            let modified = meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+            files.push((path, modified, meta.len()));
+        }
+    }
+
+    files.sort_by_key(|(_, modified, _)| *modified);
+
+    let mut total_bytes: u64 = files.iter().map(|(_, _, len)| *len).sum();
+    while files.len() > PREVIEW_CACHE_MAX_FILES || total_bytes > PREVIEW_CACHE_MAX_TOTAL_BYTES {
+        if let Some((path, _, len)) = files.first().cloned() {
+            let _ = std::fs::remove_file(&path);
+            total_bytes = total_bytes.saturating_sub(len);
+            files.remove(0);
+        } else {
+            break;
+        }
+    }
+}
+
 #[tauri::command]
 pub async fn cmd_get_preview(
     message_id: i32,
@@ -14,9 +49,9 @@ pub async fn cmd_get_preview(
     state: State<'_, TelegramState>,
     bw_state: State<'_, BandwidthManager>,
 ) -> Result<String, String> {
-    
-    let cache_dir = app_handle.path().app_data_dir().map_err(|e: tauri::Error| e.to_string())?.join("previews");
+    let cache_dir = app_handle.path().app_cache_dir().map_err(|e: tauri::Error| e.to_string())?.join("previews");
     if !cache_dir.exists() { let _ = std::fs::create_dir_all(&cache_dir); }
+    prune_preview_cache(&cache_dir);
     log::info!("Using preview cache dir: {:?}", cache_dir);
     log::info!("Preview Request: msg_id={}", message_id);
 
@@ -54,7 +89,10 @@ pub async fn cmd_get_preview(
                  _ => "bin".to_string(),
              };
              
-             let save_path = cache_dir.join(format!("{}.{}", message_id, ext));
+             let folder_key = folder_id
+                 .map(|id| id.to_string())
+                 .unwrap_or_else(|| "home".to_string());
+             let save_path = cache_dir.join(format!("{}_{}.{}", folder_key, message_id, ext));
              let save_path_str = save_path.to_string_lossy().to_string();
              
              let file_ready = if save_path.exists() {
@@ -76,6 +114,7 @@ pub async fn cmd_get_preview(
                         Ok(_) => {
                             log::info!("Preview download complete.");
                             bw_state.add_down(size);
+                            prune_preview_cache(&cache_dir);
                             true
                         },
                         Err(e) => {

--- a/app/src-tauri/src/server.rs
+++ b/app/src-tauri/src/server.rs
@@ -60,6 +60,7 @@ async fn stream_media(
                                 return HttpResponse::Ok()
                                     .insert_header(("Content-Type", mime)) 
                                     .insert_header(("Content-Length", size.to_string()))
+                                    .insert_header(("Cache-Control", "private, max-age=120"))
                                     .streaming(stream);
                             }
                         }

--- a/app/src/components/Dashboard.tsx
+++ b/app/src/components/Dashboard.tsx
@@ -51,6 +51,8 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
         _setInternalDragFileId(id);
     };
     const [playingFile, setPlayingFile] = useState<TelegramFile | null>(null);
+    const [previewContextFiles, setPreviewContextFiles] = useState<TelegramFile[]>([]);
+    const [previewContextIndex, setPreviewContextIndex] = useState(-1);
 
     useEffect(() => {
         if (store) {
@@ -113,6 +115,7 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
         setSelectedIds([]);
         setSearchTerm("");
         setPreviewFile(null);
+        setPlayingFile(null);
     }, []);
 
     const handleFocusSearch = useCallback(() => {
@@ -130,7 +133,7 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
                 if (selected.type === 'folder') {
                     setActiveFolderId(selected.id);
                 } else {
-                    setPreviewFile(selected);
+                    handlePreview(selected, displayedFiles);
                 }
             }
         }
@@ -142,7 +145,7 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
         onEscape: handleEscape,
         onSearch: handleFocusSearch,
         onEnter: handleEnter,
-        enabled: !previewFile && !showMoveModal // Disable when modals are open
+        enabled: !previewFile && !playingFile && !showMoveModal // Disable when modals are open
     });
 
 
@@ -151,6 +154,10 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
         setShowMoveModal(false);
         setSearchTerm("");
         setSearchResults([]);
+        setPreviewFile(null);
+        setPlayingFile(null);
+        setPreviewContextFiles([]);
+        setPreviewContextIndex(-1);
     }, [activeFolderId]);
 
 
@@ -182,16 +189,83 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
         }
     }
 
-    const handlePreview = (file: TelegramFile) => {
+    const handlePreview = (file: TelegramFile, orderedFiles?: TelegramFile[]) => {
+        const contextFiles = (orderedFiles || displayedFiles).filter((f) => f.type !== 'folder');
+        const contextIndex = contextFiles.findIndex((f) => f.id === file.id);
+
+        setPreviewContextFiles(contextFiles);
+        setPreviewContextIndex(contextIndex);
+
         const isMedia = ['mp4', 'webm', 'ogg', 'mov', 'mkv', 'avi', 'mp3', 'wav', 'aac', 'flac', 'm4a', 'opus']
             .some(ext => file.name.toLowerCase().endsWith(ext));
 
         if (isMedia) {
             setPlayingFile(file);
+            setPreviewFile(null);
         } else {
             setPreviewFile(file);
+            setPlayingFile(null);
         }
     };
+
+    const navigatePreview = useCallback((step: 1 | -1) => {
+        if (previewContextFiles.length === 0) return;
+
+        const currentFileId = previewFile?.id ?? playingFile?.id;
+        if (!currentFileId) return;
+
+        const currentIndex = previewContextFiles.findIndex((f) => f.id === currentFileId);
+        if (currentIndex === -1) return;
+
+        const nextIndex = (currentIndex + step + previewContextFiles.length) % previewContextFiles.length;
+        const nextFile = previewContextFiles[nextIndex];
+        if (!nextFile) return;
+
+        setPreviewContextIndex(nextIndex);
+
+        const isMedia = ['mp4', 'webm', 'ogg', 'mov', 'mkv', 'avi', 'mp3', 'wav', 'aac', 'flac', 'm4a', 'opus']
+            .some(ext => nextFile.name.toLowerCase().endsWith(ext));
+
+        if (isMedia) {
+            setPlayingFile(nextFile);
+            setPreviewFile(null);
+        } else {
+            setPreviewFile(nextFile);
+            setPlayingFile(null);
+        }
+    }, [previewContextFiles, previewFile, playingFile]);
+
+    const handleNextPreview = useCallback(() => {
+        navigatePreview(1);
+    }, [navigatePreview]);
+
+    const handlePrevPreview = useCallback(() => {
+        navigatePreview(-1);
+    }, [navigatePreview]);
+
+    const previewNeighborFiles = useCallback(() => {
+        if (previewContextFiles.length === 0) {
+            return { nextFile: null as TelegramFile | null, prevFile: null as TelegramFile | null };
+        }
+
+        const currentFileId = previewFile?.id ?? playingFile?.id;
+        if (!currentFileId) {
+            return { nextFile: null as TelegramFile | null, prevFile: null as TelegramFile | null };
+        }
+
+        const currentIdx = previewContextFiles.findIndex((f) => f.id === currentFileId);
+        if (currentIdx === -1) {
+            return { nextFile: null as TelegramFile | null, prevFile: null as TelegramFile | null };
+        }
+
+        const nextIdx = (currentIdx + 1) % previewContextFiles.length;
+        const prevIdx = (currentIdx - 1 + previewContextFiles.length) % previewContextFiles.length;
+
+        return {
+            nextFile: previewContextFiles[nextIdx] || null,
+            prevFile: previewContextFiles[prevIdx] || null,
+        };
+    }, [previewContextFiles, previewFile, playingFile]);
 
     const handleDropOnFolder = async (e: React.DragEvent, targetFolderId: number | null) => {
         e.preventDefault();
@@ -247,6 +321,8 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
         }
     };
 
+    const previewNeighbors = previewNeighborFiles();
+
     return (
         <div
             className="flex h-screen w-full overflow-hidden bg-telegram-bg relative"
@@ -271,6 +347,10 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
                     <MediaPlayer
                         file={playingFile}
                         onClose={() => setPlayingFile(null)}
+                        onNext={handleNextPreview}
+                        onPrev={handlePrevPreview}
+                        currentIndex={previewContextIndex}
+                        totalItems={previewContextFiles.length}
                         activeFolderId={activeFolderId}
                         key="media-player"
                     />
@@ -337,6 +417,12 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
                     file={previewFile}
                     activeFolderId={activeFolderId}
                     onClose={() => setPreviewFile(null)}
+                    onNext={handleNextPreview}
+                    onPrev={handlePrevPreview}
+                    currentIndex={previewContextIndex}
+                    totalItems={previewContextFiles.length}
+                    nextFile={previewNeighbors.nextFile}
+                    prevFile={previewNeighbors.prevFile}
                 />
             )}
 

--- a/app/src/components/dashboard/FileExplorer.tsx
+++ b/app/src/components/dashboard/FileExplorer.tsx
@@ -20,7 +20,7 @@ interface FileExplorerProps {
     onFileClick: (e: React.MouseEvent, id: number) => void;
     onDelete: (id: number) => void;
     onDownload: (id: number, name: string) => void;
-    onPreview: (file: TelegramFile) => void;
+    onPreview: (file: TelegramFile, orderedFiles?: TelegramFile[]) => void;
     onManualUpload: () => void;
     onSelectionClear: () => void;
     onDrop?: (e: React.DragEvent, folderId: number) => void;
@@ -94,6 +94,10 @@ export function FileExplorer({
             return sortDirection === 'asc' ? comparison : -comparison;
         });
     }, [files, sortField, sortDirection]);
+
+    const handlePreviewRequest = useCallback((file: TelegramFile) => {
+        onPreview(file, sortedFiles);
+    }, [onPreview, sortedFiles]);
 
 
     const gridRows = useMemo(() => {
@@ -243,7 +247,7 @@ export function FileExplorer({
                                                 onContextMenu={(e) => handleContextMenu(e, file)}
                                                 onDelete={() => onDelete(file.id)}
                                                 onDownload={() => onDownload(file.id, file.name)}
-                                                onPreview={() => onPreview(file)}
+                                                onPreview={() => handlePreviewRequest(file)}
                                                 onDrop={onDrop}
                                                 onDragStart={onDragStart}
                                                 onDragEnd={onDragEnd}
@@ -312,7 +316,7 @@ export function FileExplorer({
                                         onDragStart={onDragStart}
                                         onDragEnd={onDragEnd}
                                         onDrop={onDrop}
-                                        onPreview={onPreview}
+                                        onPreview={handlePreviewRequest}
                                         onDownload={onDownload}
                                         onDelete={onDelete}
                                     />
@@ -341,7 +345,7 @@ export function FileExplorer({
                         if (contextMenu.file.type === 'folder') {
                             onFileClick({ preventDefault: () => { }, stopPropagation: () => { } } as React.MouseEvent, contextMenu.file.id);
                         } else {
-                            onPreview(contextMenu.file);
+                            handlePreviewRequest(contextMenu.file);
                         }
                         setContextMenu(null);
                     }}

--- a/app/src/components/dashboard/MediaPlayer.tsx
+++ b/app/src/components/dashboard/MediaPlayer.tsx
@@ -1,22 +1,74 @@
-import { X } from 'lucide-react';
+import { useEffect } from 'react';
+import { X, ChevronLeft, ChevronRight } from 'lucide-react';
 import { TelegramFile } from '../../types';
 
 interface MediaPlayerProps {
     file: TelegramFile;
     onClose: () => void;
+    onNext?: () => void;
+    onPrev?: () => void;
+    currentIndex?: number;
+    totalItems?: number;
     activeFolderId: number | null;
 }
 
-export function MediaPlayer({ file, onClose, activeFolderId }: MediaPlayerProps) {
+export function MediaPlayer({ file, onClose, onNext, onPrev, currentIndex, totalItems, activeFolderId }: MediaPlayerProps) {
     const folderIdParam = activeFolderId !== null ? activeFolderId.toString() : 'home';
     const streamUrl = `http://localhost:14200/stream/${folderIdParam}/${file.id}`;
 
     const isVideo = ['mp4', 'webm', 'ogg', 'mov', 'mkv', 'avi'].some(ext => file.name.toLowerCase().endsWith(ext));
     const isAudio = ['mp3', 'wav', 'aac', 'flac', 'm4a', 'opus'].some(ext => file.name.toLowerCase().endsWith(ext));
 
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            const target = e.target as HTMLElement;
+            if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+                return;
+            }
+
+            const key = e.key.toLowerCase();
+
+            if (e.key === 'ArrowRight' || key === 'l') {
+                e.preventDefault();
+                onNext?.();
+                return;
+            }
+
+            if (e.key === 'ArrowLeft' || key === 'j') {
+                e.preventDefault();
+                onPrev?.();
+                return;
+            }
+
+            if (e.key === 'Escape') {
+                e.preventDefault();
+                onClose();
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [onClose, onNext, onPrev]);
+
     return (
         <div className="fixed inset-0 z-[200] bg-black/90 flex items-center justify-center p-4 backdrop-blur-md animate-in fade-in duration-200" onClick={onClose}>
             <div className="relative w-full max-w-6xl flex flex-col items-center" onClick={e => e.stopPropagation()}>
+                <button
+                    onClick={onPrev}
+                    className="absolute left-2 top-1/2 -translate-y-1/2 p-2 text-white/50 hover:text-white bg-white/10 hover:bg-white/20 rounded-full transition-all z-10"
+                    title="Previous (ArrowLeft / J)"
+                >
+                    <ChevronLeft className="w-6 h-6" />
+                </button>
+
+                <button
+                    onClick={onNext}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 p-2 text-white/50 hover:text-white bg-white/10 hover:bg-white/20 rounded-full transition-all z-10"
+                    title="Next (ArrowRight / L)"
+                >
+                    <ChevronRight className="w-6 h-6" />
+                </button>
+
                 <button
                     onClick={onClose}
                     className="absolute -top-12 right-0 p-2 text-white/50 hover:text-white bg-white/10 hover:bg-white/20 rounded-full transition-all"
@@ -46,7 +98,12 @@ export function MediaPlayer({ file, onClose, activeFolderId }: MediaPlayerProps)
 
                 <div className="mt-4 text-center">
                     <h3 className="text-lg font-medium text-white">{file.name}</h3>
-                    <p className="text-sm text-white/50">Streaming from Telegram Drive</p>
+                    <p className="text-sm text-white/50">
+                        Streaming from Telegram Drive
+                        {typeof currentIndex === 'number' && typeof totalItems === 'number' && totalItems > 0 && (
+                            <span className="ml-2">• {currentIndex + 1}/{totalItems} • Arrow/J-L</span>
+                        )}
+                    </p>
                 </div>
             </div>
         </div>

--- a/app/src/components/dashboard/PreviewModal.tsx
+++ b/app/src/components/dashboard/PreviewModal.tsx
@@ -1,22 +1,100 @@
-import { useState, useEffect } from 'react';
-import { X, File } from 'lucide-react';
+import { useState, useEffect, useRef } from 'react';
+import { X, File, ChevronLeft, ChevronRight } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { TelegramFile } from '../../types';
 
+const PREVIEW_CACHE_TTL_MS = 5 * 60 * 1000;
+const PREVIEW_CACHE_MAX_ITEMS = 8;
+
+type PreviewCacheValue = {
+    src: string;
+    cachedAt: number;
+};
+
+const previewCache = new Map<string, PreviewCacheValue>();
+const pendingPrefetch = new Set<string>();
+
+const getPreviewCacheKey = (fileId: number, folderId: number | null) => `${folderId ?? 'home'}:${fileId}`;
+
+const touchPreviewCache = (key: string, value: PreviewCacheValue) => {
+    if (previewCache.has(key)) previewCache.delete(key);
+    previewCache.set(key, value);
+
+    while (previewCache.size > PREVIEW_CACHE_MAX_ITEMS) {
+        const oldestKey = previewCache.keys().next().value;
+        if (!oldestKey) break;
+        previewCache.delete(oldestKey);
+    }
+};
+
+const getCachedPreview = (key: string): string | null => {
+    const value = previewCache.get(key);
+    if (!value) return null;
+
+    if (Date.now() - value.cachedAt > PREVIEW_CACHE_TTL_MS) {
+        previewCache.delete(key);
+        return null;
+    }
+
+    touchPreviewCache(key, value);
+    return value.src;
+};
+
+const rememberPreview = (key: string, src: string) => {
+    touchPreviewCache(key, { src, cachedAt: Date.now() });
+};
+
+const forgetPreview = (key: string) => {
+    previewCache.delete(key);
+};
+
+const isSafeToPrefetch = (name: string) => {
+    const lower = name.toLowerCase();
+    return ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg', 'heic', 'heif']
+        .some(ext => lower.endsWith(ext));
+};
+
 interface PreviewModalProps {
     file: TelegramFile;
     onClose: () => void;
+    onNext?: () => void;
+    onPrev?: () => void;
+    currentIndex?: number;
+    totalItems?: number;
+    nextFile?: TelegramFile | null;
+    prevFile?: TelegramFile | null;
     activeFolderId: number | null;
 }
 
-export function PreviewModal({ file, onClose, activeFolderId }: PreviewModalProps) {
+export function PreviewModal({ file, onClose, onNext, onPrev, currentIndex, totalItems, nextFile, prevFile, activeFolderId }: PreviewModalProps) {
     const [src, setSrc] = useState<string | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+    const [reloadNonce, setReloadNonce] = useState(0);
+    const [retryCount, setRetryCount] = useState(0);
+    const latestRequestRef = useRef(0);
+
+    useEffect(() => {
+        setRetryCount(0);
+        setReloadNonce(0);
+    }, [file.id, activeFolderId]);
 
     useEffect(() => {
         const load = async () => {
+            const key = getPreviewCacheKey(file.id, activeFolderId);
+            const shouldBypassCache = reloadNonce > 0;
+            const requestId = ++latestRequestRef.current;
+            const cachedSrc = shouldBypassCache ? null : getCachedPreview(key);
+
+            if (cachedSrc) {
+                if (requestId !== latestRequestRef.current) return;
+                setSrc(cachedSrc);
+                setLoading(false);
+                setError(null);
+                return;
+            }
+
             setLoading(true);
             setError(null);
             try {
@@ -24,27 +102,106 @@ export function PreviewModal({ file, onClose, activeFolderId }: PreviewModalProp
                     messageId: file.id,
                     folderId: activeFolderId
                 });
+                if (requestId !== latestRequestRef.current) return;
+
                 if (path) {
                     if (path.startsWith('data:')) {
                         setSrc(path);
+                        rememberPreview(key, path);
                     } else {
-                        setSrc(convertFileSrc(path));
+                        const converted = convertFileSrc(path);
+                        setSrc(converted);
+                        rememberPreview(key, converted);
                     }
                 } else {
                     setError("Preview not available");
                 }
             } catch (e) {
+                if (requestId !== latestRequestRef.current) return;
                 setError(String(e));
             } finally {
+                if (requestId !== latestRequestRef.current) return;
                 setLoading(false);
             }
         };
         load();
-    }, [file, activeFolderId]);
+    }, [file, activeFolderId, reloadNonce]);
+
+    useEffect(() => {
+        const candidates = [nextFile, prevFile].filter((f): f is TelegramFile => !!f && isSafeToPrefetch(f.name));
+
+        candidates.forEach((candidate) => {
+            const key = getPreviewCacheKey(candidate.id, activeFolderId);
+            if (getCachedPreview(key) || pendingPrefetch.has(key)) return;
+
+            pendingPrefetch.add(key);
+            invoke<string>('cmd_get_preview', {
+                messageId: candidate.id,
+                folderId: activeFolderId
+            }).then((path) => {
+                if (!path) return;
+                const normalized = path.startsWith('data:') ? path : convertFileSrc(path);
+                rememberPreview(key, normalized);
+            }).catch(() => {
+                // Ignore prefetch errors, main preview flow will handle user-visible failures.
+            }).finally(() => {
+                pendingPrefetch.delete(key);
+            });
+        });
+    }, [nextFile, prevFile, activeFolderId]);
+
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            const target = e.target as HTMLElement;
+            if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+                return;
+            }
+
+            const key = e.key.toLowerCase();
+
+            if (e.key === 'ArrowRight' || key === 'l') {
+                e.preventDefault();
+                onNext?.();
+                return;
+            }
+
+            if (e.key === 'ArrowLeft' || key === 'j') {
+                e.preventDefault();
+                onPrev?.();
+                return;
+            }
+
+            if (e.key === 'Escape') {
+                e.preventDefault();
+                onClose();
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [onClose, onNext, onPrev]);
 
     return (
         <div className="fixed inset-0 z-[150] bg-black/90 flex items-center justify-center p-4 backdrop-blur-sm" onClick={onClose}>
             <div className="relative max-w-5xl w-full max-h-screen flex flex-col items-center justify-center" onClick={e => e.stopPropagation()}>
+                <button
+                    onClick={onPrev}
+                    className="absolute left-2 top-1/2 -translate-y-1/2 p-2 bg-black/60 hover:bg-black/80 rounded-full transition-colors"
+                    style={{ color: '#ffffff' }}
+                    title="Previous (ArrowLeft / J)"
+                >
+                    <ChevronLeft className="w-6 h-6" />
+                </button>
+
+                <button
+                    onClick={onNext}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 p-2 bg-black/60 hover:bg-black/80 rounded-full transition-colors"
+                    style={{ color: '#ffffff' }}
+                    title="Next (ArrowRight / L)"
+                >
+                    <ChevronRight className="w-6 h-6" />
+                </button>
+
                 <button
                     onClick={onClose}
                     className="absolute -top-12 right-0 p-2 bg-black/60 hover:bg-black/80 rounded-full transition-colors"
@@ -71,7 +228,23 @@ export function PreviewModal({ file, onClose, activeFolderId }: PreviewModalProp
                 {!loading && !error && src && (
                     <div className="flex flex-col items-center">
                         {['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg', 'heic', 'heif'].some(ext => file.name.toLowerCase().endsWith(ext)) ? (
-                            <img src={src.startsWith('data:') ? src : `${src}?t=${Date.now()}`} className="max-w-full max-h-[85vh] object-contain rounded-lg shadow-2xl bg-black" alt="Preview" />
+                            <img
+                                src={src}
+                                className="max-w-full max-h-[85vh] object-contain rounded-lg shadow-2xl bg-black"
+                                alt="Preview"
+                                onError={() => {
+                                    const key = getPreviewCacheKey(file.id, activeFolderId);
+                                    forgetPreview(key);
+
+                                    if (retryCount < 1) {
+                                        setRetryCount((prev) => prev + 1);
+                                        setReloadNonce((prev) => prev + 1);
+                                        return;
+                                    }
+
+                                    setError('Failed to render image preview');
+                                }}
+                            />
                         ) : ['mp4', 'webm', 'ogg', 'mov'].some(ext => file.name.toLowerCase().endsWith(ext)) ? (
                             <video src={src} controls className="max-w-full max-h-[85vh] rounded-lg shadow-2xl bg-black" />
                         ) : (
@@ -87,6 +260,9 @@ export function PreviewModal({ file, onClose, activeFolderId }: PreviewModalProp
 
                 <div className="absolute bottom-[-3rem] text-white text-sm opacity-50">
                     {file.name}
+                    {typeof currentIndex === 'number' && typeof totalItems === 'number' && totalItems > 0 && (
+                        <span className="ml-3">{currentIndex + 1}/{totalItems} • Arrow/J-L</span>
+                    )}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
hi, thanks for made this awesome project! i've submitted a few improvements to the media/file preview experience, specifically adding fast navigation between files.

Key Changes:
- Added `Left/Right` and `J/L` keyboard shortcuts, plus `next/prev` buttons in the overlay. It now loops at the boundaries and skips folders automatically.
- Added a lightweight in-memory frontend cache and prefetching.
- Resolved intermittent "broken image" icons by adding guards against stale async responses and a one-time auto-retry for failed renders.