### PR TITLE
feat: integrate Google Drive import

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -14,6 +14,7 @@
     "@tanstack/react-virtual": "^3.13.18",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.6.0",
+    "@tauri-apps/plugin-opener": "^2.5.3",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-shell": "^2.3.5",
     "@tauri-apps/plugin-store": "^2.4.2",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -309,7 +309,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "actix-cors",
  "actix-rt",
@@ -325,6 +325,7 @@ dependencies = [
  "grammers-tl-types",
  "log",
  "rand 0.8.5",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "tauri",
@@ -337,7 +338,10 @@ dependencies = [
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
+ "tempfile",
  "tokio",
+ "tokio-util",
+ "urlencoding",
 ]
 
 [[package]]
@@ -857,6 +861,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -878,9 +892,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -891,7 +905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -1216,7 +1230,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.11+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -1398,12 +1412,21 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1416,6 +1439,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2059,6 +2088,17 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -2076,7 +2116,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2094,6 +2134,30 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -2103,7 +2167,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -2120,13 +2184,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -2141,13 +2218,13 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.0",
- "http-body",
- "hyper",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -2763,6 +2840,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3151,10 +3245,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -3829,6 +3961,48 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3838,9 +4012,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -3852,7 +4026,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -3862,7 +4036,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -3953,6 +4127,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3967,7 +4150,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -4093,7 +4276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4581,6 +4764,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -4597,6 +4786,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4620,7 +4830,7 @@ checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
 dependencies = [
  "bitflags 2.10.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -4710,7 +4920,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4936,7 +5146,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.13.2",
  "rustls",
  "semver",
  "serde",
@@ -5203,6 +5413,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5330,7 +5550,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -5346,7 +5566,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -5534,6 +5754,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "urlpattern"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5574,6 +5800,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -5704,6 +5936,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -6014,6 +6259,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6061,6 +6315,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -6122,6 +6391,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6140,6 +6415,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6155,6 +6436,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6188,6 +6475,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6203,6 +6496,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6224,6 +6523,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6239,6 +6544,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6268,6 +6579,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -43,4 +43,8 @@ async-stream = "0.3"
 actix-rt = "2"
 tauri-plugin-process = "2.3.1"
 rand = "0.8"
+reqwest = { version = "0.11", features = ["json", "stream"] }
+tokio-util = { version = "0.7.10", features = ["io"] }
+tempfile = "3.3.0"
+urlencoding = "2.1.3"
 

--- a/app/src-tauri/capabilities/default.json
+++ b/app/src-tauri/capabilities/default.json
@@ -12,6 +12,7 @@
     "fs:allow-appdata-read-recursive",
     "fs:allow-appdata-write-recursive",
     "fs:allow-appdata-meta-recursive",
-    "updater:default"
+    "updater:default",
+    "opener:default"
   ]
 }

--- a/app/src-tauri/src/commands/fs.rs
+++ b/app/src-tauri/src/commands/fs.rs
@@ -1,24 +1,27 @@
-use tauri::{State, Emitter};
+use crate::bandwidth::BandwidthManager;
+use crate::commands::utils::{map_error, resolve_peer};
+use crate::models::{FileMetadata, FolderMetadata};
+use crate::TelegramState;
+use grammers_client::types::media::Uploaded;
 use grammers_client::types::{Media, Peer};
 use grammers_client::InputMessage;
 use grammers_tl_types as tl;
-use crate::TelegramState;
-use crate::models::{FolderMetadata, FileMetadata};
-use crate::bandwidth::BandwidthManager;
-use crate::commands::utils::{resolve_peer, map_error};
+use tauri::{Emitter, State};
+use tokio::io::AsyncRead;
 
 #[tauri::command]
 pub async fn cmd_create_folder(
     name: String,
     state: State<'_, TelegramState>,
 ) -> Result<FolderMetadata, String> {
-    let client_opt = {
-        state.client.lock().await.clone()
-    };
-    
+    let client_opt = { state.client.lock().await.clone() };
+
     // --- MOCK ---
     if client_opt.is_none() {
-        let mock_id = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs() as i64;
+        let mock_id = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
         log::info!("[MOCK] Created folder '{}' with ID {}", name, mock_id);
         return Ok(FolderMetadata {
             id: mock_id,
@@ -29,40 +32,48 @@ pub async fn cmd_create_folder(
     // -----------
     let client = client_opt.unwrap();
     log::info!("Creating Telegram Channel: {}", name);
-    
-    let result = client.invoke(&tl::functions::channels::CreateChannel {
-        broadcast: true,
-        megagroup: false,
-        title: format!("{} [TD]", name),
-        about: "Telegram Drive Storage Folder\n[telegram-drive-folder]".to_string(),
-        geo_point: None,
-        address: None,
-        for_import: false,
-        forum: false,
-        ttl_period: None, // Initial creation TTL
-    }).await.map_err(map_error)?;
-    
+
+    let result = client
+        .invoke(&tl::functions::channels::CreateChannel {
+            broadcast: true,
+            megagroup: false,
+            title: format!("{} [TD]", name),
+            about: "Telegram Drive Storage Folder\n[telegram-drive-folder]".to_string(),
+            geo_point: None,
+            address: None,
+            for_import: false,
+            forum: false,
+            ttl_period: None, // Initial creation TTL
+        })
+        .await
+        .map_err(map_error)?;
+
     let (chat_id, access_hash) = match result {
         tl::enums::Updates::Updates(u) => {
-             let chat = u.chats.first().ok_or("No chat in updates")?;
-             match chat {
-                 tl::enums::Chat::Channel(c) => (c.id, c.access_hash.unwrap_or(0)),
-                 _ => return Err("Created chat is not a channel".to_string()),
-             }
-        },
-        _ => return Err("Unexpected response (not Updates::Updates)".to_string()), 
+            let chat = u.chats.first().ok_or("No chat in updates")?;
+            match chat {
+                tl::enums::Chat::Channel(c) => (c.id, c.access_hash.unwrap_or(0)),
+                _ => return Err("Created chat is not a channel".to_string()),
+            }
+        }
+        _ => return Err("Unexpected response (not Updates::Updates)".to_string()),
     };
 
     // Explicitly Disable TTL
     let _input_channel = tl::enums::InputChannel::Channel(tl::types::InputChannel {
-         channel_id: chat_id,
-         access_hash,
+        channel_id: chat_id,
+        access_hash,
     });
 
-    let _ = client.invoke(&tl::functions::messages::SetHistoryTtl {
-        peer: tl::enums::InputPeer::Channel(tl::types::InputPeerChannel { channel_id: chat_id, access_hash }),
-        period: 0, 
-    }).await;
+    let _ = client
+        .invoke(&tl::functions::messages::SetHistoryTtl {
+            peer: tl::enums::InputPeer::Channel(tl::types::InputPeerChannel {
+                channel_id: chat_id,
+                access_hash,
+            }),
+            period: 0,
+        })
+        .await;
 
     Ok(FolderMetadata {
         id: chat_id,
@@ -76,10 +87,8 @@ pub async fn cmd_delete_folder(
     folder_id: i64,
     state: State<'_, TelegramState>,
 ) -> Result<bool, String> {
-    let client_opt = {
-        state.client.lock().await.clone()
-    };
-    
+    let client_opt = { state.client.lock().await.clone() };
+
     if client_opt.is_none() {
         log::info!("[MOCK] Deleted folder ID {}", folder_id);
         return Ok(true);
@@ -88,30 +97,77 @@ pub async fn cmd_delete_folder(
     log::info!("Deleting folder/channel: {}", folder_id);
 
     let peer = resolve_peer(&client, Some(folder_id)).await?;
-    
+
     let input_channel = match peer {
         Peer::Channel(c) => {
-             let chan = &c.raw;
-             tl::enums::InputChannel::Channel(tl::types::InputChannel {
-                 channel_id: chan.id,
-                 access_hash: chan.access_hash.ok_or("No access hash for channel")?,
-             })
-        },
+            let chan = &c.raw;
+            tl::enums::InputChannel::Channel(tl::types::InputChannel {
+                channel_id: chan.id,
+                access_hash: chan.access_hash.ok_or("No access hash for channel")?,
+            })
+        }
         _ => return Err("Only channels (folders) can be deleted.".to_string()),
     };
-    
-    client.invoke(&tl::functions::channels::DeleteChannel {
-        channel: input_channel,
-    }).await.map_err(|e| format!("Failed to delete channel: {}", e))?;
-    
+
+    client
+        .invoke(&tl::functions::channels::DeleteChannel {
+            channel: input_channel,
+        })
+        .await
+        .map_err(|e| format!("Failed to delete channel: {}", e))?;
+
     Ok(true)
 }
-
 
 #[derive(Clone, serde::Serialize)]
 struct ProgressPayload {
     id: String,
     percent: u8,
+}
+
+pub async fn send_uploaded_to_folder(
+    client: &grammers_client::Client,
+    uploaded: Uploaded,
+    folder_id: Option<i64>,
+) -> Result<(), String> {
+    let peer = resolve_peer(client, folder_id).await?;
+    let message = InputMessage::new().text("").file(uploaded);
+    client
+        .send_message(&peer, message)
+        .await
+        .map_err(map_error)?;
+    Ok(())
+}
+
+pub async fn upload_stream_to_folder<S: AsyncRead + Unpin>(
+    client: &grammers_client::Client,
+    stream: &mut S,
+    size: usize,
+    filename: String,
+    folder_id: Option<i64>,
+) -> Result<(), String> {
+    let uploaded = client
+        .upload_stream(stream, size, filename)
+        .await
+        .map_err(map_error)?;
+
+    send_uploaded_to_folder(client, uploaded, folder_id).await
+}
+
+pub async fn upload_path_to_folder(
+    client: &grammers_client::Client,
+    path: &str,
+    folder_id: Option<i64>,
+) -> Result<(), String> {
+    let path_clone = path.to_string();
+    let client_clone = client.clone();
+    let uploaded_file =
+        tauri::async_runtime::spawn(async move { client_clone.upload_file(&path_clone).await })
+            .await
+            .map_err(|e| format!("Task join error: {}", e))?
+            .map_err(map_error)?;
+
+    send_uploaded_to_folder(client, uploaded_file, folder_id).await
 }
 
 #[tauri::command]
@@ -135,31 +191,29 @@ pub async fn cmd_upload_file(
         return Ok("Mock upload successful".to_string());
     }
     let client = client_opt.unwrap();
-    
-    // Emit start progress
+
     if !tid.is_empty() {
-        let _ = app_handle.emit("upload-progress", ProgressPayload { id: tid.clone(), percent: 0 });
+        let _ = app_handle.emit(
+            "upload-progress",
+            ProgressPayload {
+                id: tid.clone(),
+                percent: 0,
+            },
+        );
     }
 
-    let path_clone = path.clone();
-    let client_clone = client.clone();
-    
-    let uploaded_file = tauri::async_runtime::spawn(async move {
-        client_clone.upload_file(&path_clone).await
-    }).await.map_err(|e| format!("Task join error: {}", e))?
-      .map_err(map_error)?;
-        
-    let message = InputMessage::new().text("").file(uploaded_file);
+    upload_path_to_folder(&client, &path, folder_id).await?;
 
-    let peer = resolve_peer(&client, folder_id).await?;
-    
-    client.send_message(&peer, message).await.map_err(map_error)?;
-    
     bw_state.add_up(size);
 
-    // Emit completion
     if !tid.is_empty() {
-        let _ = app_handle.emit("upload-progress", ProgressPayload { id: tid, percent: 100 });
+        let _ = app_handle.emit(
+            "upload-progress",
+            ProgressPayload {
+                id: tid,
+                percent: 100,
+            },
+        );
     }
 
     Ok("File uploaded successfully".to_string())
@@ -172,14 +226,21 @@ pub async fn cmd_delete_file(
     state: State<'_, TelegramState>,
 ) -> Result<bool, String> {
     let client_opt = { state.client.lock().await.clone() };
-    if client_opt.is_none() { 
-         log::info!("[MOCK] Deleted message {} from folder {:?}", message_id, folder_id);
-        return Ok(true); 
+    if client_opt.is_none() {
+        log::info!(
+            "[MOCK] Deleted message {} from folder {:?}",
+            message_id,
+            folder_id
+        );
+        return Ok(true);
     }
     let client = client_opt.unwrap();
 
     let peer = resolve_peer(&client, folder_id).await?;
-    client.delete_messages(&peer, &[message_id]).await.map_err(|e| e.to_string())?;
+    client
+        .delete_messages(&peer, &[message_id])
+        .await
+        .map_err(|e| e.to_string())?;
     Ok(true)
 }
 
@@ -196,24 +257,36 @@ pub async fn cmd_download_file(
     let tid = transfer_id.unwrap_or_default();
 
     let client_opt = { state.client.lock().await.clone() };
-    if client_opt.is_none() { 
-        log::info!("[MOCK] Downloaded message {} from {:?} to {}", message_id, folder_id, save_path);
-        if let Err(e) = std::fs::write(&save_path, b"Mock Content") { return Err(e.to_string()); }
+    if client_opt.is_none() {
+        log::info!(
+            "[MOCK] Downloaded message {} from {:?} to {}",
+            message_id,
+            folder_id,
+            save_path
+        );
+        if let Err(e) = std::fs::write(&save_path, b"Mock Content") {
+            return Err(e.to_string());
+        }
         return Ok("Download successful".to_string());
     }
     let client = client_opt.unwrap();
-    
+
     let peer = resolve_peer(&client, folder_id).await?;
 
     // Use get_messages_by_id for efficient message lookup (same as server.rs)
-    let messages = client.get_messages_by_id(&peer, &[message_id]).await.map_err(|e| e.to_string())?;
-    
-    let msg = messages.into_iter()
+    let messages = client
+        .get_messages_by_id(&peer, &[message_id])
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let msg = messages
+        .into_iter()
         .flatten()
         .next()
         .ok_or_else(|| "Message not found".to_string())?;
 
-    let media = msg.media()
+    let media = msg
+        .media()
         .ok_or_else(|| "No media in message".to_string())?;
 
     let total_size = match &media {
@@ -221,12 +294,18 @@ pub async fn cmd_download_file(
         Media::Photo(_) => 1024 * 1024,
         _ => 0,
     };
-    
+
     bw_state.can_transfer(total_size)?;
 
     // Emit start
     if !tid.is_empty() {
-        let _ = app_handle.emit("download-progress", ProgressPayload { id: tid.clone(), percent: 0 });
+        let _ = app_handle.emit(
+            "download-progress",
+            ProgressPayload {
+                id: tid.clone(),
+                percent: 0,
+            },
+        );
     }
 
     // Stream download with per-chunk progress
@@ -239,13 +318,19 @@ pub async fn cmd_download_file(
         let bytes = chunk.map_err(|e| format!("Download chunk error: {}", e))?;
         std::io::Write::write_all(&mut file, &bytes).map_err(|e| e.to_string())?;
         downloaded += bytes.len() as u64;
-        
+
         if !tid.is_empty() && total_size > 0 {
             let percent = ((downloaded as f64 / total_size as f64) * 100.0).min(100.0) as u8;
             // Only emit when percent actually changes to avoid event spam
             if percent != last_percent {
                 last_percent = percent;
-                let _ = app_handle.emit("download-progress", ProgressPayload { id: tid.clone(), percent });
+                let _ = app_handle.emit(
+                    "download-progress",
+                    ProgressPayload {
+                        id: tid.clone(),
+                        percent,
+                    },
+                );
             }
         }
     }
@@ -254,7 +339,13 @@ pub async fn cmd_download_file(
 
     // Emit completion
     if !tid.is_empty() {
-        let _ = app_handle.emit("download-progress", ProgressPayload { id: tid, percent: 100 });
+        let _ = app_handle.emit(
+            "download-progress",
+            ProgressPayload {
+                id: tid,
+                percent: 100,
+            },
+        );
     }
 
     Ok("Download successful".to_string())
@@ -267,24 +358,34 @@ pub async fn cmd_move_files(
     target_folder_id: Option<i64>,
     state: State<'_, TelegramState>,
 ) -> Result<bool, String> {
-    if source_folder_id == target_folder_id { return Ok(true); }
+    if source_folder_id == target_folder_id {
+        return Ok(true);
+    }
     let client_opt = { state.client.lock().await.clone() };
-    if client_opt.is_none() { 
-        log::info!("[MOCK] Moved msgs {:?} from {:?} to {:?}", message_ids, source_folder_id, target_folder_id);
-        return Ok(true); 
+    if client_opt.is_none() {
+        log::info!(
+            "[MOCK] Moved msgs {:?} from {:?} to {:?}",
+            message_ids,
+            source_folder_id,
+            target_folder_id
+        );
+        return Ok(true);
     }
     let client = client_opt.unwrap();
 
     let source_peer = resolve_peer(&client, source_folder_id).await?;
     let target_peer = resolve_peer(&client, target_folder_id).await?;
 
-    match client.forward_messages(&target_peer, &message_ids, &source_peer).await {
-        Ok(_) => {},
+    match client
+        .forward_messages(&target_peer, &message_ids, &source_peer)
+        .await
+    {
+        Ok(_) => {}
         Err(e) => return Err(format!("Forward failed: {}", e)),
     }
-    
+
     match client.delete_messages(&source_peer, &message_ids).await {
-        Ok(_) => {},
+        Ok(_) => {}
         Err(e) => return Err(format!("Delete original failed: {}", e)),
     }
 
@@ -297,13 +398,13 @@ pub async fn cmd_get_files(
     state: State<'_, TelegramState>,
 ) -> Result<Vec<FileMetadata>, String> {
     let client_opt = { state.client.lock().await.clone() };
-    if client_opt.is_none() { 
+    if client_opt.is_none() {
         log::info!("[MOCK] Returning mock files for folder {:?}", folder_id);
         return Ok(Vec::new()); // No mock files for now
     }
     let client = client_opt.unwrap();
     let mut files = Vec::new();
-    
+
     let peer = resolve_peer(&client, folder_id).await?;
 
     let mut msgs = client.iter_messages(&peer);
@@ -314,14 +415,28 @@ pub async fn cmd_get_files(
                     let n = d.name().to_string();
                     let s = d.size();
                     let m = d.mime_type().map(|s| s.to_string());
-                    let e = std::path::Path::new(&n).extension().map(|os| os.to_str().unwrap_or("").to_string());
+                    let e = std::path::Path::new(&n)
+                        .extension()
+                        .map(|os| os.to_str().unwrap_or("").to_string());
                     (n, s, m, e)
-                },
-                Media::Photo(_) => ("Photo.jpg".to_string(), 0, Some("image/jpeg".into()), Some("jpg".into())),
+                }
+                Media::Photo(_) => (
+                    "Photo.jpg".to_string(),
+                    0,
+                    Some("image/jpeg".into()),
+                    Some("jpg".into()),
+                ),
                 _ => ("Unknown".to_string(), 0, None, None),
             };
             files.push(FileMetadata {
-                id: msg.id() as i64, folder_id, name, size: size as u64, mime_type: mime, file_ext: ext, created_at: msg.date().to_string(), icon_type: "file".into()
+                id: msg.id() as i64,
+                folder_id,
+                name,
+                size: size as u64,
+                mime_type: mime,
+                file_ext: ext,
+                created_at: msg.date().to_string(),
+                icon_type: "file".into(),
             });
         }
     }
@@ -335,50 +450,66 @@ pub async fn cmd_search_global(
     state: State<'_, TelegramState>,
 ) -> Result<Vec<FileMetadata>, String> {
     let client_opt = { state.client.lock().await.clone() };
-    if client_opt.is_none() { 
+    if client_opt.is_none() {
         return Ok(Vec::new());
     }
     let client = client_opt.unwrap();
     let mut files = Vec::new();
-    
+
     log::info!("Searching global for: {}", query);
 
-    let result = client.invoke(&tl::functions::messages::SearchGlobal {
-        q: query,
-        filter: tl::enums::MessagesFilter::InputMessagesFilterDocument,
-        min_date: 0,
-        max_date: 0,
-        offset_rate: 0,
-        offset_peer: tl::enums::InputPeer::Empty,
-        offset_id: 0,
-        limit: 50,
-        folder_id: None,
-        broadcasts_only: false,
-        groups_only: false,
-        users_only: false,
-    }).await.map_err(map_error)?;
+    let result = client
+        .invoke(&tl::functions::messages::SearchGlobal {
+            q: query,
+            filter: tl::enums::MessagesFilter::InputMessagesFilterDocument,
+            min_date: 0,
+            max_date: 0,
+            offset_rate: 0,
+            offset_peer: tl::enums::InputPeer::Empty,
+            offset_id: 0,
+            limit: 50,
+            folder_id: None,
+            broadcasts_only: false,
+            groups_only: false,
+            users_only: false,
+        })
+        .await
+        .map_err(map_error)?;
 
     if let tl::enums::messages::Messages::Messages(msgs) = result {
         for msg in msgs.messages {
             if let tl::enums::Message::Message(m) = msg {
                 if let Some(tl::enums::MessageMedia::Document(d)) = m.media {
                     if let tl::enums::Document::Document(doc) = d.document.unwrap() {
-                        let name = doc.attributes.iter().find_map(|a| match a {
-                            tl::enums::DocumentAttribute::Filename(f) => Some(f.file_name.clone()),
-                            _ => None
-                        }).unwrap_or("Unknown".to_string());
+                        let name = doc
+                            .attributes
+                            .iter()
+                            .find_map(|a| match a {
+                                tl::enums::DocumentAttribute::Filename(f) => {
+                                    Some(f.file_name.clone())
+                                }
+                                _ => None,
+                            })
+                            .unwrap_or("Unknown".to_string());
                         let size = doc.size as u64;
                         let mime = doc.mime_type.clone();
-                        let ext = std::path::Path::new(&name).extension().map(|os| os.to_str().unwrap_or("").to_string());
+                        let ext = std::path::Path::new(&name)
+                            .extension()
+                            .map(|os| os.to_str().unwrap_or("").to_string());
                         let folder_id = match m.peer_id {
                             tl::enums::Peer::Channel(c) => Some(c.channel_id),
                             tl::enums::Peer::User(u) => Some(u.user_id),
                             tl::enums::Peer::Chat(c) => Some(c.chat_id),
                         };
                         files.push(FileMetadata {
-                            id: m.id as i64, folder_id, name, size,
-                            mime_type: Some(mime), file_ext: ext,
-                            created_at: m.date.to_string(), icon_type: "file".into()
+                            id: m.id as i64,
+                            folder_id,
+                            name,
+                            size,
+                            mime_type: Some(mime),
+                            file_ext: ext,
+                            created_at: m.date.to_string(),
+                            icon_type: "file".into(),
                         });
                     }
                 }
@@ -389,22 +520,35 @@ pub async fn cmd_search_global(
             if let tl::enums::Message::Message(m) = msg {
                 if let Some(tl::enums::MessageMedia::Document(d)) = m.media {
                     if let tl::enums::Document::Document(doc) = d.document.unwrap() {
-                        let name = doc.attributes.iter().find_map(|a| match a {
-                            tl::enums::DocumentAttribute::Filename(f) => Some(f.file_name.clone()),
-                            _ => None
-                        }).unwrap_or("Unknown".to_string());
+                        let name = doc
+                            .attributes
+                            .iter()
+                            .find_map(|a| match a {
+                                tl::enums::DocumentAttribute::Filename(f) => {
+                                    Some(f.file_name.clone())
+                                }
+                                _ => None,
+                            })
+                            .unwrap_or("Unknown".to_string());
                         let size = doc.size as u64;
                         let mime = doc.mime_type.clone();
-                        let ext = std::path::Path::new(&name).extension().map(|os| os.to_str().unwrap_or("").to_string());
+                        let ext = std::path::Path::new(&name)
+                            .extension()
+                            .map(|os| os.to_str().unwrap_or("").to_string());
                         let folder_id = match m.peer_id {
                             tl::enums::Peer::Channel(c) => Some(c.channel_id),
                             tl::enums::Peer::User(u) => Some(u.user_id),
                             tl::enums::Peer::Chat(c) => Some(c.chat_id),
                         };
                         files.push(FileMetadata {
-                            id: m.id as i64, folder_id, name, size,
-                            mime_type: Some(mime), file_ext: ext,
-                            created_at: m.date.to_string(), icon_type: "file".into()
+                            id: m.id as i64,
+                            folder_id,
+                            name,
+                            size,
+                            mime_type: Some(mime),
+                            file_ext: ext,
+                            created_at: m.date.to_string(),
+                            icon_type: "file".into(),
                         });
                     }
                 }
@@ -420,14 +564,14 @@ pub async fn cmd_scan_folders(
     state: State<'_, TelegramState>,
 ) -> Result<Vec<FolderMetadata>, String> {
     let client_opt = { state.client.lock().await.clone() };
-    if client_opt.is_none() { 
+    if client_opt.is_none() {
         return Ok(Vec::new());
     }
     let client = client_opt.unwrap();
-    
+
     let mut folders = Vec::new();
     let mut dialogs = client.iter_dialogs();
-    
+
     log::info!("Starting Folder Scan...");
 
     while let Some(dialog) = dialogs.next().await.map_err(|e| e.to_string())? {
@@ -436,15 +580,25 @@ pub async fn cmd_scan_folders(
                 let id = c.raw.id;
                 let name = c.raw.title.clone();
                 let access_hash = c.raw.access_hash.unwrap_or(0);
-                
+
                 log::debug!("[SCAN] Processing Channel: '{}' (ID: {})", name, id);
 
                 // Strategy 1: Title
                 if name.to_lowercase().contains("[td]") {
                     log::info!(" -> MATCH via Title: {}", name);
-                    let display_name = name.replace(" [TD]", "").replace(" [td]", "").replace("[TD]", "").replace("[td]", "").trim().to_string();
-                    folders.push(FolderMetadata { id, name: display_name, parent_id: None });
-                    continue; 
+                    let display_name = name
+                        .replace(" [TD]", "")
+                        .replace(" [td]", "")
+                        .replace("[TD]", "")
+                        .replace("[td]", "")
+                        .trim()
+                        .to_string();
+                    folders.push(FolderMetadata {
+                        id,
+                        name: display_name,
+                        parent_id: None,
+                    });
+                    continue;
                 }
 
                 // Strategy 2: About
@@ -452,27 +606,34 @@ pub async fn cmd_scan_folders(
                     channel_id: c.raw.id,
                     access_hash,
                 });
-                
-                match client.invoke(&tl::functions::channels::GetFullChannel {
-                    channel: input_chan,
-                }).await {
+
+                match client
+                    .invoke(&tl::functions::channels::GetFullChannel {
+                        channel: input_chan,
+                    })
+                    .await
+                {
                     Ok(tl::enums::messages::ChatFull::Full(f)) => {
                         if let tl::enums::ChatFull::Full(cf) = f.full_chat {
-                             if cf.about.contains("[telegram-drive-folder]") {
-                                 log::info!(" -> MATCH via About: {}", name);
-                                 folders.push(FolderMetadata { id, name: name.clone(), parent_id: None });
-                             }
+                            if cf.about.contains("[telegram-drive-folder]") {
+                                log::info!(" -> MATCH via About: {}", name);
+                                folders.push(FolderMetadata {
+                                    id,
+                                    name: name.clone(),
+                                    parent_id: None,
+                                });
+                            }
                         }
-                    },
+                    }
                     Err(e) => log::warn!(" -> Failed to get full info: {}", e),
                 }
-            },
+            }
             peer => {
                 log::debug!("[SCAN] Skipped Peer: {:?}", peer);
             }
         }
     }
-    
+
     log::info!("Scan complete. Found {} folders.", folders.len());
     Ok(folders)
 }

--- a/app/src-tauri/src/commands/mod.rs
+++ b/app/src-tauri/src/commands/mod.rs
@@ -1,7 +1,7 @@
+use grammers_client::types::{LoginToken, PasswordToken};
+use grammers_client::Client;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use grammers_client::{Client};
-use grammers_client::types::{LoginToken, PasswordToken};
 
 /// Tracks the lifecycle of the Telegram connection
 /// 
@@ -24,14 +24,14 @@ pub struct TelegramState {
 
 pub mod auth;
 pub mod fs;
-pub mod preview;
-pub mod utils;
 pub mod network;
+pub mod preview;
 pub mod streaming;
+pub mod utils;
 
 pub use auth::*;
 pub use fs::*;
-pub use preview::*;
-pub use utils::*;
 pub use network::*;
+pub use preview::*;
 pub use streaming::*;
+pub use utils::*;

--- a/app/src-tauri/src/google_drive.rs
+++ b/app/src-tauri/src/google_drive.rs
@@ -1,0 +1,667 @@
+use crate::bandwidth::BandwidthManager;
+use crate::TelegramState;
+use futures::StreamExt;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tauri::{Emitter, State};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio_util::io::StreamReader;
+
+const GOOGLE_AUTH_ENDPOINT: &str = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_ENDPOINT: &str = "https://oauth2.googleapis.com/token";
+const GOOGLE_DRIVE_FILES_ENDPOINT: &str = "https://www.googleapis.com/drive/v3/files";
+const DRIVE_SCOPE: &str = "https://www.googleapis.com/auth/drive.readonly";
+const GOOGLE_DOC_MIME: &str = "application/vnd.google-apps.document";
+const GOOGLE_SHEET_MIME: &str = "application/vnd.google-apps.spreadsheet";
+const GOOGLE_SLIDES_MIME: &str = "application/vnd.google-apps.presentation";
+const GOOGLE_DRAWING_MIME: &str = "application/vnd.google-apps.drawing";
+const REDIRECT_URI: &str = "http://localhost:53682/oauth/google/callback";
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct GdTokenResponse {
+    pub access_token: String,
+    pub expires_in: i64,
+    pub refresh_token: Option<String>,
+    pub scope: String,
+    pub token_type: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct GdFileItem {
+    pub id: String,
+    pub name: String,
+    pub mime_type: String,
+    pub size: Option<String>,
+    pub modified_time: Option<String>,
+    pub export_links: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct GdListResponse {
+    pub files: Vec<GdFileItem>,
+    pub next_page_token: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct GdImportItem {
+    pub id: String,
+    pub name: String,
+    pub size: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct GdAuthUrlResponse {
+    pub auth_url: String,
+    pub redirect_uri: String,
+    pub scope: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct GdOAuthCodeResponse {
+    pub code: String,
+    pub state: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct ProgressPayload {
+    id: String,
+    percent: u8,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct MigrationPayload {
+    id: String,
+    filename: String,
+    status: String,
+    percent: u8,
+    error: Option<String>,
+}
+
+use crate::commands::fs::upload_stream_to_folder;
+
+#[tauri::command]
+pub async fn cmd_gd_auth_url(
+    client_id: String,
+    state: Option<String>,
+) -> Result<GdAuthUrlResponse, String> {
+    if client_id.trim().is_empty() {
+        return Err("Google Client ID empty".to_string());
+    }
+
+    let mut url = reqwest::Url::parse(GOOGLE_AUTH_ENDPOINT).map_err(|e| e.to_string())?;
+
+    let oauth_state = state.unwrap_or_else(|| {
+        format!(
+            "td-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis())
+                .unwrap_or(0)
+        )
+    });
+
+    {
+        let mut qp = url.query_pairs_mut();
+        qp.append_pair("client_id", client_id.trim());
+        qp.append_pair("redirect_uri", REDIRECT_URI);
+        qp.append_pair("response_type", "code");
+        qp.append_pair("scope", DRIVE_SCOPE);
+        qp.append_pair("access_type", "offline");
+        qp.append_pair("prompt", "select_account");
+        qp.append_pair("state", &oauth_state);
+    }
+
+    Ok(GdAuthUrlResponse {
+        auth_url: url.to_string(),
+        redirect_uri: REDIRECT_URI.to_string(),
+        scope: DRIVE_SCOPE.to_string(),
+    })
+}
+
+#[tauri::command]
+pub async fn cmd_gd_exchange_token(
+    client_id: String,
+    client_secret: String,
+    code: String,
+) -> Result<GdTokenResponse, String> {
+    if client_id.trim().is_empty() || client_secret.trim().is_empty() {
+        return Err("Google Client ID/Secret empty".to_string());
+    }
+    if code.trim().is_empty() {
+        return Err("OAuth code empty".to_string());
+    }
+
+    let http = Client::new();
+
+    let mut form = HashMap::new();
+    form.insert("client_id", client_id.trim().to_string());
+    form.insert("client_secret", client_secret.trim().to_string());
+    form.insert("code", code.trim().to_string());
+    form.insert("grant_type", "authorization_code".to_string());
+    form.insert("redirect_uri", REDIRECT_URI.to_string());
+
+    let resp = http
+        .post(GOOGLE_TOKEN_ENDPOINT)
+        .form(&form)
+        .send()
+        .await
+        .map_err(|e| format!("Google token request failed: {}", e))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!(
+            "Google token exchange failed [{}]: {}",
+            status, body
+        ));
+    }
+
+    let token = resp
+        .json::<GdTokenResponse>()
+        .await
+        .map_err(|e| format!("Invalid token response: {}", e))?;
+
+    Ok(token)
+}
+
+#[tauri::command]
+pub async fn cmd_gd_list_files(
+    access_token: String,
+    folder_id: Option<String>,
+    page_token: Option<String>,
+    page_size: Option<u32>,
+) -> Result<GdListResponse, String> {
+    if access_token.trim().is_empty() {
+        return Err("Google access token empty".to_string());
+    }
+
+    let target_folder = folder_id.unwrap_or_else(|| "root".to_string());
+    let mut q = format!(
+        "'{}' in parents and trashed = false",
+        target_folder.replace('"', "")
+    );
+    let _corpora = "user";
+
+    // If reading the root of "Shared with me", we need a different query.
+    if target_folder == "sharedWithMe" {
+        q = "sharedWithMe = true and trashed = false".to_string();
+    }
+
+    let http = Client::new();
+    let mut req = http
+        .get(GOOGLE_DRIVE_FILES_ENDPOINT)
+        .bearer_auth(access_token.trim())
+        .query(&[
+            ("q", q.as_str()),
+            (
+                "fields",
+                "nextPageToken,files(id,name,mimeType,size,modifiedTime,exportLinks)",
+            ),
+            ("orderBy", "folder,name"),
+            ("supportsAllDrives", "true"),
+            ("includeItemsFromAllDrives", "true"),
+            ("corpora", "allDrives"),
+        ]);
+
+    let size = page_size.unwrap_or(100).clamp(1, 1000);
+    req = req.query(&[("pageSize", size)]);
+
+    if let Some(token) = page_token {
+        if !token.trim().is_empty() {
+            req = req.query(&[("pageToken", token.trim())]);
+        }
+    }
+
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| format!("Google list request failed: {}", e))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!("Google list failed [{}]: {}", status, body));
+    }
+
+    let data = resp
+        .json::<GdListResponse>()
+        .await
+        .map_err(|e| format!("Invalid list response: {}", e))?;
+
+    Ok(data)
+}
+
+#[tauri::command]
+pub async fn cmd_gd_import_files(
+    access_token: String,
+    items: Vec<GdImportItem>,
+    folder_id: Option<i64>,
+    app_handle: tauri::AppHandle,
+    state: State<'_, TelegramState>,
+    bw_state: State<'_, BandwidthManager>,
+) -> Result<Vec<String>, String> {
+    if access_token.trim().is_empty() {
+        return Err("Google access token empty".to_string());
+    }
+    if items.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let client_opt = { state.client.lock().await.clone() };
+    if client_opt.is_none() {
+        return Err("Telegram client not connected".to_string());
+    }
+    let tg_client = client_opt.unwrap();
+
+    let http = Client::new();
+    let mut results = Vec::new();
+
+    for item in items {
+        let transfer_id = format!("gd-{}", item.id);
+
+        let _ = app_handle.emit(
+            "migration-progress",
+            MigrationPayload {
+                id: transfer_id.clone(),
+                filename: item.name.clone(),
+                status: "starting".to_string(),
+                percent: 0,
+                error: None,
+            },
+        );
+
+        let import_res: Result<(), String> = async {
+            let file_meta_url = format!("{}/{}", GOOGLE_DRIVE_FILES_ENDPOINT, item.id);
+
+            let meta_resp = http
+                .get(&file_meta_url)
+                .bearer_auth(access_token.trim())
+                .query(&[("fields", "id,name,size,mimeType,exportLinks")])
+                .send()
+                .await
+                .map_err(|e| format!("Meta request failed: {}", e))?;
+
+            if !meta_resp.status().is_success() {
+                let status = meta_resp.status();
+                let body = meta_resp.text().await.unwrap_or_default();
+                return Err(format!("Meta request failed [{}]: {}", status, body));
+            }
+
+            let meta = meta_resp
+                .json::<GdFileItem>()
+                .await
+                .map_err(|e| format!("Invalid meta response: {}", e))?;
+
+            if meta.mime_type == "application/vnd.google-apps.folder" {
+                return Err("Folder import not supported yet. Select files only.".to_string());
+            }
+            let export_target = google_export_target(&meta.mime_type);
+            let size = if export_target.is_some() {
+                0
+            } else {
+                meta.size
+                    .as_deref()
+                    .or(item.size.map(|s| s.to_string()).as_deref())
+                    .ok_or_else(|| "Google file size missing".to_string())?
+                    .parse::<u64>()
+                    .map_err(|e| format!("Invalid Google file size: {}", e))?
+            };
+
+            if size > 0 {
+                bw_state.can_transfer(size)?;
+            }
+
+            let _ = app_handle.emit(
+                "migration-progress",
+                MigrationPayload {
+                    id: transfer_id.clone(),
+                    filename: meta.name.clone(),
+                    status: "downloading".to_string(),
+                    percent: 10,
+                    error: None,
+                },
+            );
+
+            let (download_url, upload_name) = if let Some((mime, extension)) = export_target {
+                (
+                    format!(
+                        "{}/{}/export?mimeType={}",
+                        GOOGLE_DRIVE_FILES_ENDPOINT,
+                        item.id,
+                        urlencoding::encode(mime)
+                    ),
+                    ensure_extension(&meta.name, extension),
+                )
+            } else {
+                (
+                    format!("{}?alt=media&supportsAllDrives=true", file_meta_url),
+                    meta.name.clone(),
+                )
+            };
+
+            let media_resp = http
+                .get(&download_url)
+                .bearer_auth(access_token.trim())
+                .send()
+                .await
+                .map_err(|e| format!("Drive download failed: {}", e))?;
+
+            if !media_resp.status().is_success() {
+                let status = media_resp.status();
+                let body = media_resp.text().await.unwrap_or_default();
+                return Err(format!("Drive download failed [{}]: {}", status, body));
+            }
+
+            let content_size = media_resp.content_length().unwrap_or(size);
+            if content_size > 0 {
+                bw_state.can_transfer(content_size)?;
+            }
+
+            let stream = media_resp
+                .bytes_stream()
+                .map(|chunk| chunk.map_err(std::io::Error::other));
+            let mut reader = StreamReader::new(stream);
+
+            let _ = app_handle.emit(
+                "migration-progress",
+                MigrationPayload {
+                    id: transfer_id.clone(),
+                    filename: meta.name.clone(),
+                    status: "uploading".to_string(),
+                    percent: 30,
+                    error: None,
+                },
+            );
+            let _ = app_handle.emit(
+                "upload-progress",
+                ProgressPayload {
+                    id: transfer_id.clone(),
+                    percent: 30,
+                },
+            );
+
+            upload_stream_to_folder(
+                &tg_client,
+                &mut reader,
+                content_size as usize,
+                upload_name.clone(),
+                folder_id,
+            )
+            .await?;
+
+            bw_state.add_up(content_size);
+
+            let _ = app_handle.emit(
+                "migration-progress",
+                MigrationPayload {
+                    id: transfer_id.clone(),
+                    filename: meta.name.clone(),
+                    status: "done".to_string(),
+                    percent: 100,
+                    error: None,
+                },
+            );
+            let _ = app_handle.emit(
+                "upload-progress",
+                ProgressPayload {
+                    id: transfer_id.clone(),
+                    percent: 100,
+                },
+            );
+
+            Ok(())
+        }
+        .await;
+
+        match import_res {
+            Ok(()) => {
+                results.push(format!("{}:ok", item.name));
+            }
+            Err(e) => {
+                let _ = app_handle.emit(
+                    "migration-progress",
+                    MigrationPayload {
+                        id: transfer_id,
+                        filename: item.name.clone(),
+                        status: "error".to_string(),
+                        percent: 0,
+                        error: Some(e.clone()),
+                    },
+                );
+                results.push(format!("{}:error:{}", item.name, e));
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+pub fn sanitize_filename(name: &str) -> String {
+    let trimmed = name.trim();
+    let fallback = "file";
+    let base = if trimmed.is_empty() {
+        fallback
+    } else {
+        trimmed
+    };
+    base.replace(['/', '\\'], "_")
+}
+
+pub async fn fallback_import_via_tempfile(
+    tg_client: &grammers_client::Client,
+    access_token: &str,
+    file_id: &str,
+    filename: &str,
+    size: u64,
+    folder_id: Option<i64>,
+) -> Result<(), String> {
+    let http = Client::new();
+    let download_url = format!("{}/{}", GOOGLE_DRIVE_FILES_ENDPOINT, file_id);
+
+    let mut temp = tempfile::Builder::new()
+        .prefix("td-gd-")
+        .suffix(&format!("-{}", sanitize_filename(filename)))
+        .tempfile()
+        .map_err(|e| format!("Create tempfile failed: {}", e))?;
+
+    let mut resp = http
+        .get(&download_url)
+        .bearer_auth(access_token)
+        .query(&[("alt", "media")])
+        .send()
+        .await
+        .map_err(|e| format!("Drive download failed: {}", e))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!("Drive download failed [{}]: {}", status, body));
+    }
+
+    while let Some(chunk) = resp.chunk().await.map_err(|e| e.to_string())? {
+        use std::io::Write;
+        temp.write_all(&chunk).map_err(|e| e.to_string())?;
+    }
+
+    let path = temp.path().to_path_buf();
+    let mut file = tokio::fs::File::open(&path)
+        .await
+        .map_err(|e| format!("Open tempfile failed: {}", e))?;
+
+    upload_stream_to_folder(
+        tg_client,
+        &mut file,
+        size as usize,
+        sanitize_filename(filename),
+        folder_id,
+    )
+    .await
+}
+
+fn google_export_target(mime: &str) -> Option<(&'static str, &'static str)> {
+    match mime {
+        GOOGLE_DOC_MIME => Some((
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "docx",
+        )),
+        GOOGLE_SHEET_MIME => Some((
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "xlsx",
+        )),
+        GOOGLE_SLIDES_MIME => Some((
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            "pptx",
+        )),
+        GOOGLE_DRAWING_MIME => Some(("image/png", "png")),
+        _ => None,
+    }
+}
+
+fn ensure_extension(name: &str, ext: &str) -> String {
+    if name
+        .to_lowercase()
+        .ends_with(&format!(".{}", ext.to_lowercase()))
+    {
+        name.to_string()
+    } else {
+        format!("{}.{}", name, ext)
+    }
+}
+
+#[tauri::command]
+pub async fn cmd_gd_wait_for_auth_code() -> Result<GdOAuthCodeResponse, String> {
+    let listener = TcpListener::bind("127.0.0.1:53682")
+        .await
+        .map_err(|e| format!("Bind error: {}", e))?;
+
+    // Timeout so we don't hang forever if user closes browser
+    let accept_future = listener.accept();
+    let accept_res = tokio::time::timeout(std::time::Duration::from_secs(120), accept_future).await;
+
+    let (mut stream, _) = match accept_res {
+        Ok(Ok(res)) => res,
+        Ok(Err(e)) => return Err(format!("Accept error: {}", e)),
+        Err(_) => return Err("Timeout waiting for Google auth callback".to_string()),
+    };
+
+    let mut buf = [0; 4096];
+    let n = stream
+        .read(&mut buf)
+        .await
+        .map_err(|e| format!("Read error: {}", e))?;
+    let req = String::from_utf8_lossy(&buf[..n]);
+
+    let mut code = String::new();
+    let mut state = None;
+
+    if let Some(line) = req.lines().next() {
+        if let Some(path) = line.split_whitespace().nth(1) {
+            if let Some(query) = path.split('?').nth(1) {
+                for pair in query.split('&') {
+                    let mut parts = pair.split('=');
+                    if let (Some(k), Some(v)) = (parts.next(), parts.next()) {
+                        if k == "code" {
+                            code = v.to_string();
+                        } else if k == "state" {
+                            state = Some(v.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let response = if code.is_empty() {
+        concat!(
+            "HTTP/1.1 400 Bad Request\r\n",
+            "Content-Type: text/html\r\n",
+            "Connection: close\r\n\r\n",
+            "<!DOCTYPE html><html><head><title>Auth Failed</title>",
+            "<style>",
+            "body{background:#0f172a;color:#e2e8f0;font-family:system-ui,-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;}",
+            "div{background:#1e293b;padding:2rem;border-radius:12px;text-align:center;box-shadow:0 10px 15px -3px rgb(0 0 0/0.1),0 4px 6px -4px rgb(0 0 0/0.1);border:1px solid #334155;}",
+            "h2{color:#f87171;margin-top:0;} p{color:#94a3b8;}",
+            "</style></head><body>",
+            "<div><h2>Authentication Failed</h2><p>No authorization code found.</p><p>You can close this window.</p></div>",
+            "</body></html>"
+        )
+    } else {
+        concat!(
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Type: text/html\r\n",
+            "Connection: close\r\n\r\n",
+            "<!DOCTYPE html><html><head><title>Auth Success</title>",
+            "<style>",
+            "body{background:#0f172a;color:#e2e8f0;font-family:system-ui,-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;}",
+            "div{background:#1e293b;padding:2rem;border-radius:12px;text-align:center;box-shadow:0 10px 15px -3px rgb(0 0 0/0.1),0 4px 6px -4px rgb(0 0 0/0.1);border:1px solid #334155;}",
+            "h2{color:#38bdf8;margin-top:0;} p{color:#94a3b8;}",
+            "</style></head><body>",
+            "<div><h2>Authentication Successful!</h2><p>You can return to Telegram Drive.</p><p style='font-size:0.875rem;margin-top:1.5rem;color:#64748b;'>Closing window automatically in 3 seconds...</p></div>",
+            "<script>setTimeout(()=>window.close(), 3000);</script>",
+            "</body></html>"
+        )
+    };
+
+    let _ = stream.write_all(response.as_bytes()).await;
+    let _ = stream.flush().await;
+    // VERY IMPORTANT: Shutdown the stream so the browser knows the response is fully sent
+    let _ = stream.shutdown().await;
+
+    if code.is_empty() {
+        return Err("No code found in redirect URL".to_string());
+    }
+
+    Ok(GdOAuthCodeResponse { code, state })
+}
+
+#[tauri::command]
+pub async fn cmd_gd_refresh_token(
+    client_id: String,
+    client_secret: String,
+    refresh_token: String,
+) -> Result<GdTokenResponse, String> {
+    if client_id.trim().is_empty() || client_secret.trim().is_empty() {
+        return Err("Google Client ID/Secret empty".to_string());
+    }
+    if refresh_token.trim().is_empty() {
+        return Err("Refresh token empty".to_string());
+    }
+
+    let http = Client::new();
+
+    let mut form = HashMap::new();
+    form.insert("client_id", client_id.trim().to_string());
+    form.insert("client_secret", client_secret.trim().to_string());
+    form.insert("refresh_token", refresh_token.trim().to_string());
+    form.insert("grant_type", "refresh_token".to_string());
+
+    let resp = http
+        .post(GOOGLE_TOKEN_ENDPOINT)
+        .form(&form)
+        .send()
+        .await
+        .map_err(|e| format!("Google token refresh failed: {}", e))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!(
+            "Google token refresh failed [{}]: {}",
+            status, body
+        ));
+    }
+
+    let token = resp
+        .json::<GdTokenResponse>()
+        .await
+        .map_err(|e| format!("Invalid token refresh response: {}", e))?;
+
+    Ok(token)
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,14 +1,15 @@
 pub mod models;
 
-pub mod commands;
 pub mod bandwidth;
+pub mod commands;
+pub mod google_drive;
 
+use commands::streaming::StreamToken;
+use commands::TelegramState;
+use rand::Rng;
+use std::sync::Arc;
 use tauri::Manager;
 use tokio::sync::Mutex;
-use std::sync::Arc;
-use commands::TelegramState;
-use commands::streaming::StreamToken;
-use rand::Rng;
 
 pub mod server;
 
@@ -55,7 +56,7 @@ pub fn run() {
             app.manage(bandwidth::BandwidthManager::new(app.handle()));
             app.manage(StreamToken(stream_token.clone()));
             app.manage(ActixServerHandle(server_handle_for_setup.clone()));
-            
+
             // Start Streaming Server on dedicated thread (Actix needs its own runtime)
             let state = Arc::new(app.state::<TelegramState>().inner().clone());
             let token_for_server = stream_token.clone();
@@ -74,7 +75,7 @@ pub fn run() {
                     }
                 });
             });
-            
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -100,6 +101,12 @@ pub fn run() {
             commands::cmd_clean_cache,
             commands::cmd_get_thumbnail,
             commands::cmd_get_stream_token,
+            google_drive::cmd_gd_auth_url,
+            google_drive::cmd_gd_exchange_token,
+            google_drive::cmd_gd_refresh_token,
+            google_drive::cmd_gd_wait_for_auth_code,
+            google_drive::cmd_gd_list_files,
+            google_drive::cmd_gd_import_files,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/app/src/components/Dashboard.tsx
+++ b/app/src/components/Dashboard.tsx
@@ -1,470 +1,663 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
-import { AnimatePresence } from 'framer-motion';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { invoke } from '@tauri-apps/api/core';
-import { toast } from 'sonner';
-
-import { TelegramFile, BandwidthStats } from '../types';
-import { formatBytes, isMediaFile, isPdfFile } from '../utils';
-
-// Components
-import { Sidebar } from './dashboard/Sidebar';
-import { TopBar } from './dashboard/TopBar';
-import { FileExplorer } from './dashboard/FileExplorer';
-import { UploadQueue } from './dashboard/UploadQueue';
-import { DownloadQueue } from './dashboard/DownloadQueue';
-import { MoveToFolderModal } from './dashboard/MoveToFolderModal';
-import { PreviewModal } from './dashboard/PreviewModal';
-import { MediaPlayer } from './dashboard/MediaPlayer';
-import { DragDropOverlay } from './dashboard/DragDropOverlay';
-import { ExternalDropBlocker } from './dashboard/ExternalDropBlocker';
-import { PdfViewer } from './dashboard/PdfViewer';
-
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
+import { AnimatePresence, motion } from "framer-motion";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { useFileDownload } from "../hooks/useFileDownload";
+import { useFileOperations } from "../hooks/useFileOperations";
+import { useFileUpload } from "../hooks/useFileUpload";
+import { useGoogleDriveMigration } from "../hooks/useGoogleDriveMigration";
+import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 // Hooks
-import { useTelegramConnection } from '../hooks/useTelegramConnection';
-import { useFileOperations } from '../hooks/useFileOperations';
-import { useFileUpload } from '../hooks/useFileUpload';
-import { useFileDownload } from '../hooks/useFileDownload';
-import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
+import { useTelegramConnection } from "../hooks/useTelegramConnection";
+import type { BandwidthStats, TelegramFile } from "../types";
+import { formatBytes, isMediaFile, isPdfFile } from "../utils";
+import { DownloadQueue } from "./dashboard/DownloadQueue";
+import { DragDropOverlay } from "./dashboard/DragDropOverlay";
+import { ExternalDropBlocker } from "./dashboard/ExternalDropBlocker";
+import { FileExplorer } from "./dashboard/FileExplorer";
+import { GoogleDriveImportModal } from "./dashboard/GoogleDriveImportModal";
+import { MediaPlayer } from "./dashboard/MediaPlayer";
+import { MigrationQueue } from "./dashboard/MigrationQueue";
+import { MoveToFolderModal } from "./dashboard/MoveToFolderModal";
+import { PdfViewer } from "./dashboard/PdfViewer";
+import { PreviewModal } from "./dashboard/PreviewModal";
+// Components
+import { Sidebar } from "./dashboard/Sidebar";
+import { TopBar } from "./dashboard/TopBar";
+import { UploadQueue } from "./dashboard/UploadQueue";
+
+interface PendingGoogleDriveImport {
+	token: string;
+	items: any[];
+	duplicates: any[];
+}
 
 export function Dashboard({ onLogout }: { onLogout: () => void }) {
-    const queryClient = useQueryClient();
-
-
-    const {
-        store, folders, activeFolderId, setActiveFolderId, isSyncing, isConnected,
-        handleLogout, handleSyncFolders, handleCreateFolder, handleFolderDelete
-    } = useTelegramConnection(onLogout);
-
-
-    const [previewFile, setPreviewFile] = useState<TelegramFile | null>(null);
-    const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
-    const [selectedIds, setSelectedIds] = useState<number[]>([]);
-    const [showMoveModal, setShowMoveModal] = useState(false);
-    const [searchTerm, setSearchTerm] = useState("");
-    const [searchResults, setSearchResults] = useState<TelegramFile[]>([]);
-    const [isSearching, setIsSearching] = useState(false);
-    const [internalDragFileId, _setInternalDragFileId] = useState<number | null>(null);
-    const internalDragRef = useRef<number | null>(null);
-
-    const setInternalDragFileId = (id: number | null) => {
-        internalDragRef.current = id;
-        _setInternalDragFileId(id);
-    };
-    const [playingFile, setPlayingFile] = useState<TelegramFile | null>(null);
-    const [pdfFile, setPdfFile] = useState<TelegramFile | null>(null);
-    const [previewContextFiles, setPreviewContextFiles] = useState<TelegramFile[]>([]);
-    const [previewContextIndex, setPreviewContextIndex] = useState(-1);
-
-    useEffect(() => {
-        if (store) {
-            store.get<'grid' | 'list'>('viewMode').then((saved) => {
-                if (saved) setViewMode(saved);
-            });
-        }
-    }, [store]);
-
-    useEffect(() => {
-        if (store) {
-            store.set('viewMode', viewMode).then(() => store.save());
-        }
-    }, [store, viewMode]);
-
-
-    const { data: allFiles = [], isLoading, error } = useQuery({
-        queryKey: ['files', activeFolderId],
-        queryFn: () => invoke<any[]>('cmd_get_files', { folderId: activeFolderId }).then(res => res.map(f => ({
-            ...f,
-            sizeStr: formatBytes(f.size),
-            type: f.icon_type || (f.name.endsWith('/') ? 'folder' : 'file')
-        }))),
-        enabled: !!store,
-    });
-
-    const displayedFiles = searchTerm.length > 2
-        ? searchResults
-        : allFiles.filter((f: TelegramFile) => f.name.toLowerCase().includes(searchTerm.toLowerCase()));
-
-    const { data: bandwidth } = useQuery({
-        queryKey: ['bandwidth'],
-        queryFn: () => invoke<BandwidthStats>('cmd_get_bandwidth'),
-        refetchInterval: 5000,
-        enabled: !!store
-    });
-
-
-    const {
-        handleDelete, handleBulkDelete, handleBulkDownload,
-        handleBulkMove, handleDownloadFolder, handleGlobalSearch
-
-    } = useFileOperations(activeFolderId, selectedIds, setSelectedIds, displayedFiles);
-
-    const { uploadQueue, setUploadQueue, handleManualUpload, cancelAll: cancelUploads, isDragging } = useFileUpload(activeFolderId, store);
-    const { downloadQueue, queueDownload, clearFinished: clearDownloads, cancelAll: cancelDownloads } = useFileDownload(store);
-
-
-    const handleSelectAll = useCallback(() => {
-        setSelectedIds(displayedFiles.map(f => f.id));
-    }, [displayedFiles]);
-
-    const handleKeyboardDelete = useCallback(() => {
-        if (selectedIds.length > 0) {
-            handleBulkDelete();
-        }
-    }, [selectedIds, handleBulkDelete]);
-
-    const handleEscape = useCallback(() => {
-        setSelectedIds([]);
-        setSearchTerm("");
-        setPreviewFile(null);
-        setPlayingFile(null);
-        setPdfFile(null);
-    }, []);
-
-    const handleFocusSearch = useCallback(() => {
-        const searchInput = document.querySelector('input[placeholder="Search files..."]') as HTMLInputElement;
-        if (searchInput) {
-            searchInput.focus();
-            searchInput.select();
-        }
-    }, []);
-
-    const handleEnter = useCallback(() => {
-        if (selectedIds.length === 1) {
-            const selected = displayedFiles.find(f => f.id === selectedIds[0]);
-            if (selected) {
-                if (selected.type === 'folder') {
-                    setActiveFolderId(selected.id);
-                } else {
-                    handlePreview(selected, displayedFiles);
-                }
-            }
-        }
-    }, [selectedIds, displayedFiles, setActiveFolderId]);
-
-    useKeyboardShortcuts({
-        onSelectAll: handleSelectAll,
-        onDelete: handleKeyboardDelete,
-        onEscape: handleEscape,
-        onSearch: handleFocusSearch,
-        onEnter: handleEnter,
-        enabled: !previewFile && !playingFile && !pdfFile && !showMoveModal // Disable when modals are open
-    });
-
-
-    useEffect(() => {
-        setSelectedIds([]);
-        setShowMoveModal(false);
-        setSearchTerm("");
-        setSearchResults([]);
-        setPreviewFile(null);
-        setPlayingFile(null);
-        setPdfFile(null);
-        setPreviewContextFiles([]);
-        setPreviewContextIndex(-1);
-    }, [activeFolderId]);
-
-
-    useEffect(() => {
-        if (searchTerm.length <= 2) {
-            setSearchResults([]);
-            return;
-        }
-
-        const timer = setTimeout(async () => {
-            setIsSearching(true);
-            const results = await handleGlobalSearch(searchTerm);
-            setSearchResults(results);
-            setIsSearching(false);
-        }, 500);
-
-        return () => clearTimeout(timer);
-    }, [searchTerm]);
-
-
-
-
-    const handleFileClick = (e: React.MouseEvent, id: number) => {
-        e.stopPropagation();
-        if (e.metaKey || e.ctrlKey) {
-            setSelectedIds(ids => ids.includes(id) ? ids.filter(i => i !== id) : [...ids, id]);
-        } else {
-            setSelectedIds([id]);
-        }
-    }
-
-    const handlePreview = (file: TelegramFile, orderedFiles?: TelegramFile[]) => {
-        const contextFiles = (orderedFiles || displayedFiles).filter((f) => f.type !== 'folder');
-        const contextIndex = contextFiles.findIndex((f) => f.id === file.id);
-
-        setPreviewContextFiles(contextFiles);
-        setPreviewContextIndex(contextIndex);
-
-        const isMedia = isMediaFile(file.name);
-        const isPdf = isPdfFile(file.name);
-
-        if (isMedia) {
-            setPlayingFile(file);
-            setPreviewFile(null);
-            setPdfFile(null);
-        } else if (isPdf) {
-            setPdfFile(file);
-            setPreviewFile(null);
-            setPlayingFile(null);
-        } else {
-            setPreviewFile(file);
-            setPlayingFile(null);
-            setPdfFile(null);
-        }
-    };
-
-    const navigatePreview = useCallback((step: 1 | -1) => {
-        if (previewContextFiles.length === 0) return;
-
-        const currentFileId = previewFile?.id ?? playingFile?.id ?? pdfFile?.id;
-        if (!currentFileId) return;
-
-        const currentIndex = previewContextFiles.findIndex((f) => f.id === currentFileId);
-        if (currentIndex === -1) return;
-
-        const nextIndex = (currentIndex + step + previewContextFiles.length) % previewContextFiles.length;
-        const nextFile = previewContextFiles[nextIndex];
-        if (!nextFile) return;
-
-        setPreviewContextIndex(nextIndex);
-
-        const isMedia = isMediaFile(nextFile.name);
-        const isPdf = isPdfFile(nextFile.name);
-
-        if (isMedia) {
-            setPlayingFile(nextFile);
-            setPreviewFile(null);
-            setPdfFile(null);
-        } else if (isPdf) {
-            setPdfFile(nextFile);
-            setPreviewFile(null);
-            setPlayingFile(null);
-        } else {
-            setPreviewFile(nextFile);
-            setPlayingFile(null);
-            setPdfFile(null);
-        }
-    }, [previewContextFiles, previewFile, playingFile, pdfFile]);
-
-    const handleNextPreview = useCallback(() => {
-        navigatePreview(1);
-    }, [navigatePreview]);
-
-    const handlePrevPreview = useCallback(() => {
-        navigatePreview(-1);
-    }, [navigatePreview]);
-
-    const previewNeighborFiles = useCallback(() => {
-        if (previewContextFiles.length === 0) {
-            return { nextFile: null as TelegramFile | null, prevFile: null as TelegramFile | null };
-        }
-
-        const currentFileId = previewFile?.id ?? playingFile?.id ?? pdfFile?.id;
-        if (!currentFileId) {
-            return { nextFile: null as TelegramFile | null, prevFile: null as TelegramFile | null };
-        }
-
-        const currentIdx = previewContextFiles.findIndex((f) => f.id === currentFileId);
-        if (currentIdx === -1) {
-            return { nextFile: null as TelegramFile | null, prevFile: null as TelegramFile | null };
-        }
-
-        const nextIdx = (currentIdx + 1) % previewContextFiles.length;
-        const prevIdx = (currentIdx - 1 + previewContextFiles.length) % previewContextFiles.length;
-
-        return {
-            nextFile: previewContextFiles[nextIdx] || null,
-            prevFile: previewContextFiles[prevIdx] || null,
-        };
-    }, [previewContextFiles, previewFile, playingFile, pdfFile]);
-
-    const handleDropOnFolder = async (e: React.DragEvent, targetFolderId: number | null) => {
-        e.preventDefault();
-        e.stopPropagation();
-
-        const dataTransferFileId = e.dataTransfer.getData("application/x-telegram-file-id");
-
-        if (activeFolderId === targetFolderId) return;
-
-        const fileId = internalDragRef.current || (dataTransferFileId ? parseInt(dataTransferFileId) : null);
-
-        if (fileId) {
-            try {
-                const idsToMove = selectedIds.includes(fileId) ? selectedIds : [fileId];
-
-                await invoke('cmd_move_files', {
-                    messageIds: idsToMove,
-                    sourceFolderId: activeFolderId,
-                    targetFolderId: targetFolderId
-                });
-
-                queryClient.invalidateQueries({ queryKey: ['files', activeFolderId] });
-
-                if (selectedIds.includes(fileId)) setSelectedIds([]);
-
-                toast.success(`Moved ${idsToMove.length} file(s).`);
-
-                setInternalDragFileId(null);
-            } catch {
-                toast.error(`Failed to move file(s).`);
-            }
-        }
-    }
-
-    const currentFolderName = activeFolderId === null
-        ? "Saved Messages"
-        : folders.find(f => f.id === activeFolderId)?.name || "Folder";
-
-
-    const handleRootDragOver = (e: React.DragEvent) => {
-        if (internalDragRef.current) {
-            e.preventDefault();
-            e.stopPropagation();
-            e.dataTransfer.dropEffect = 'move';
-        }
-    };
-
-    const handleRootDragEnter = (e: React.DragEvent) => {
-        if (internalDragRef.current) {
-            e.preventDefault();
-            e.stopPropagation();
-            e.dataTransfer.dropEffect = 'move';
-        }
-    };
-
-    const previewNeighbors = previewNeighborFiles();
-
-    return (
-        <div
-            className="flex h-screen w-full overflow-hidden bg-telegram-bg relative"
-            onClick={() => setSelectedIds([])}
-            onDragOver={handleRootDragOver}
-            onDragEnter={handleRootDragEnter}
-        >
-
-            <ExternalDropBlocker onUploadClick={handleManualUpload} />
-
-            <AnimatePresence>
-                {showMoveModal && (
-                    <MoveToFolderModal
-                        folders={folders}
-                        onClose={() => setShowMoveModal(false)}
-                        onSelect={handleBulkMove}
-                        activeFolderId={activeFolderId}
-                        key="move-modal"
-                    />
-                )}
-                {playingFile && (
-                    <MediaPlayer
-                        file={playingFile}
-                        onClose={() => setPlayingFile(null)}
-                        onNext={handleNextPreview}
-                        onPrev={handlePrevPreview}
-                        currentIndex={previewContextIndex}
-                        totalItems={previewContextFiles.length}
-                        activeFolderId={activeFolderId}
-                        key="media-player"
-                    />
-                )}
-                {pdfFile && (
-                    <PdfViewer
-                        file={pdfFile}
-                        onClose={() => setPdfFile(null)}
-                        onNext={handleNextPreview}
-                        onPrev={handlePrevPreview}
-                        currentIndex={previewContextIndex}
-                        totalItems={previewContextFiles.length}
-                        activeFolderId={activeFolderId}
-                        key="pdf-viewer"
-                    />
-                )}
-                {isDragging && internalDragFileId === null && <DragDropOverlay key="drag-drop-overlay" />}
-            </AnimatePresence>
-
-            <Sidebar
-                folders={folders}
-                activeFolderId={activeFolderId}
-                setActiveFolderId={setActiveFolderId}
-                onDrop={handleDropOnFolder}
-                onDelete={handleFolderDelete}
-                onCreate={handleCreateFolder}
-                isSyncing={isSyncing}
-                isConnected={isConnected}
-                onSync={handleSyncFolders}
-                onLogout={handleLogout}
-                bandwidth={bandwidth || null}
-            />
-
-            <main className="flex-1 flex flex-col" onClick={(e) => { if (e.target === e.currentTarget) setSelectedIds([]); }}>
-                <TopBar
-                    currentFolderName={currentFolderName}
-                    selectedIds={selectedIds}
-                    onShowMoveModal={() => setShowMoveModal(true)}
-                    onBulkDownload={handleBulkDownload}
-                    onBulkDelete={handleBulkDelete}
-                    onDownloadFolder={handleDownloadFolder}
-                    viewMode={viewMode}
-                    setViewMode={setViewMode}
-                    searchTerm={searchTerm}
-                    onSearchChange={setSearchTerm}
-                />
-                {searchTerm.length > 2 && (
-                    <div className="px-6 pt-4 pb-0">
-                        <h2 className="text-sm font-medium text-telegram-subtext">
-                            Search Results for <span className="text-telegram-primary">"{searchTerm}"</span>
-                        </h2>
-                    </div>
-                )}
-                <FileExplorer
-
-                    files={displayedFiles}
-                    loading={isLoading || isSearching}
-                    error={error}
-                    viewMode={viewMode}
-                    selectedIds={selectedIds}
-                    activeFolderId={activeFolderId}
-                    onFileClick={handleFileClick}
-                    onDelete={handleDelete}
-                    onDownload={(id, name) => queueDownload(id, name, activeFolderId)}
-                    onPreview={handlePreview}
-                    onManualUpload={handleManualUpload}
-                    onSelectionClear={() => setSelectedIds([])}
-                    onDrop={handleDropOnFolder}
-                    onDragStart={(fileId) => setInternalDragFileId(fileId)}
-                    onDragEnd={() => setTimeout(() => setInternalDragFileId(null), 50)}
-                />
-            </main>
-
-            {previewFile && (
-                <PreviewModal
-                    file={previewFile}
-                    activeFolderId={activeFolderId}
-                    onClose={() => setPreviewFile(null)}
-                    onNext={handleNextPreview}
-                    onPrev={handlePrevPreview}
-                    currentIndex={previewContextIndex}
-                    totalItems={previewContextFiles.length}
-                    nextFile={previewNeighbors.nextFile}
-                    prevFile={previewNeighbors.prevFile}
-                />
-            )}
-
-
-            <UploadQueue
-                items={uploadQueue}
-                onClearFinished={() => setUploadQueue(q => q.filter(i => i.status !== 'success' && i.status !== 'error' && i.status !== 'cancelled'))}
-                onCancelAll={cancelUploads}
-            />
-            <DownloadQueue
-                items={downloadQueue}
-                onClearFinished={clearDownloads}
-                onCancelAll={cancelDownloads}
-            />
-        </div>
-    );
+	const queryClient = useQueryClient();
+
+	const {
+		store,
+		folders,
+		activeFolderId,
+		setActiveFolderId,
+		isSyncing,
+		isConnected,
+		handleLogout,
+		handleSyncFolders,
+		handleCreateFolder,
+		handleFolderDelete,
+	} = useTelegramConnection(onLogout);
+
+	const [previewFile, setPreviewFile] = useState<TelegramFile | null>(null);
+	const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
+	const [selectedIds, setSelectedIds] = useState<number[]>([]);
+	const [showMoveModal, setShowMoveModal] = useState(false);
+	const [showGoogleDriveImportModal, setShowGoogleDriveImportModal] =
+		useState(false);
+	const [pendingGoogleDriveImport, setPendingGoogleDriveImport] =
+		useState<PendingGoogleDriveImport | null>(null);
+	const [searchTerm, setSearchTerm] = useState("");
+	const [searchResults, setSearchResults] = useState<TelegramFile[]>([]);
+	const [isSearching, setIsSearching] = useState(false);
+	const [internalDragFileId, _setInternalDragFileId] = useState<number | null>(
+		null,
+	);
+	const internalDragRef = useRef<number | null>(null);
+
+	const setInternalDragFileId = (id: number | null) => {
+		internalDragRef.current = id;
+		_setInternalDragFileId(id);
+	};
+	const [playingFile, setPlayingFile] = useState<TelegramFile | null>(null);
+	const [pdfFile, setPdfFile] = useState<TelegramFile | null>(null);
+	const [previewContextFiles, setPreviewContextFiles] = useState<
+		TelegramFile[]
+	>([]);
+	const [previewContextIndex, setPreviewContextIndex] = useState(-1);
+
+	useEffect(() => {
+		if (store) {
+			store.get<"grid" | "list">("viewMode").then((saved) => {
+				if (saved) setViewMode(saved);
+			});
+		}
+	}, [store]);
+
+	useEffect(() => {
+		if (store) {
+			store.set("viewMode", viewMode).then(() => store.save());
+		}
+	}, [store, viewMode]);
+
+	const {
+		data: allFiles = [],
+		isLoading,
+		error,
+	} = useQuery({
+		queryKey: ["files", activeFolderId],
+		queryFn: () =>
+			invoke<any[]>("cmd_get_files", { folderId: activeFolderId }).then((res) =>
+				res.map((f) => ({
+					...f,
+					sizeStr: formatBytes(f.size),
+					type: f.icon_type || (f.name.endsWith("/") ? "folder" : "file"),
+				})),
+			),
+		enabled: !!store,
+	});
+
+	const displayedFiles =
+		searchTerm.length > 2
+			? searchResults
+			: allFiles.filter((f: TelegramFile) =>
+					f.name.toLowerCase().includes(searchTerm.toLowerCase()),
+				);
+
+	const { data: bandwidth } = useQuery({
+		queryKey: ["bandwidth"],
+		queryFn: () => invoke<BandwidthStats>("cmd_get_bandwidth"),
+		refetchInterval: 5000,
+		enabled: !!store,
+	});
+
+	const {
+		handleDelete,
+		handleBulkDelete,
+		handleBulkDownload,
+		handleBulkMove,
+		handleDownloadFolder,
+		handleGlobalSearch,
+	} = useFileOperations(
+		activeFolderId,
+		selectedIds,
+		setSelectedIds,
+		displayedFiles,
+	);
+
+	const {
+		uploadQueue,
+		setUploadQueue,
+		handleManualUpload,
+		cancelAll: cancelUploads,
+		isDragging,
+	} = useFileUpload(activeFolderId, store);
+	const {
+		downloadQueue,
+		queueDownload,
+		clearFinished: clearDownloads,
+		cancelAll: cancelDownloads,
+	} = useFileDownload(store);
+	const {
+		migrationQueue,
+		importFiles,
+		clearFinished: clearFinishedMigrations,
+	} = useGoogleDriveMigration(activeFolderId);
+
+	const handleSelectAll = useCallback(() => {
+		setSelectedIds(displayedFiles.map((f) => f.id));
+	}, [displayedFiles]);
+
+	const handleKeyboardDelete = useCallback(() => {
+		if (selectedIds.length > 0) {
+			handleBulkDelete();
+		}
+	}, [selectedIds, handleBulkDelete]);
+
+	const handleEscape = useCallback(() => {
+		setSelectedIds([]);
+		setSearchTerm("");
+		setPreviewFile(null);
+		setPlayingFile(null);
+		setPdfFile(null);
+	}, []);
+
+	const handleFocusSearch = useCallback(() => {
+		const searchInput = document.querySelector(
+			'input[placeholder="Search files..."]',
+		) as HTMLInputElement;
+		if (searchInput) {
+			searchInput.focus();
+			searchInput.select();
+		}
+	}, []);
+
+	const handleEnter = useCallback(() => {
+		if (selectedIds.length === 1) {
+			const selected = displayedFiles.find((f) => f.id === selectedIds[0]);
+			if (selected) {
+				if (selected.type === "folder") {
+					setActiveFolderId(selected.id);
+				} else {
+					handlePreview(selected, displayedFiles);
+				}
+			}
+		}
+	}, [selectedIds, displayedFiles, setActiveFolderId]);
+
+	useKeyboardShortcuts({
+		onSelectAll: handleSelectAll,
+		onDelete: handleKeyboardDelete,
+		onEscape: handleEscape,
+		onSearch: handleFocusSearch,
+		onEnter: handleEnter,
+		enabled: !previewFile && !playingFile && !pdfFile && !showMoveModal, // Disable when modals are open
+	});
+
+	useEffect(() => {
+		setSelectedIds([]);
+		setShowMoveModal(false);
+		setSearchTerm("");
+		setSearchResults([]);
+		setPreviewFile(null);
+		setPlayingFile(null);
+		setPdfFile(null);
+		setPreviewContextFiles([]);
+		setPreviewContextIndex(-1);
+	}, [activeFolderId]);
+
+	useEffect(() => {
+		if (searchTerm.length <= 2) {
+			setSearchResults([]);
+			return;
+		}
+
+		const timer = setTimeout(async () => {
+			setIsSearching(true);
+			const results = await handleGlobalSearch(searchTerm);
+			setSearchResults(results);
+			setIsSearching(false);
+		}, 500);
+
+		return () => clearTimeout(timer);
+	}, [searchTerm]);
+
+	const handleFileClick = (e: React.MouseEvent, id: number) => {
+		e.stopPropagation();
+		if (e.metaKey || e.ctrlKey) {
+			setSelectedIds((ids) =>
+				ids.includes(id) ? ids.filter((i) => i !== id) : [...ids, id],
+			);
+		} else {
+			setSelectedIds([id]);
+		}
+	};
+
+	const handlePreview = (file: TelegramFile, orderedFiles?: TelegramFile[]) => {
+		const contextFiles = (orderedFiles || displayedFiles).filter(
+			(f) => f.type !== "folder",
+		);
+		const contextIndex = contextFiles.findIndex((f) => f.id === file.id);
+
+		setPreviewContextFiles(contextFiles);
+		setPreviewContextIndex(contextIndex);
+
+		const isMedia = isMediaFile(file.name);
+		const isPdf = isPdfFile(file.name);
+
+		if (isMedia) {
+			setPlayingFile(file);
+			setPreviewFile(null);
+			setPdfFile(null);
+		} else if (isPdf) {
+			setPdfFile(file);
+			setPreviewFile(null);
+			setPlayingFile(null);
+		} else {
+			setPreviewFile(file);
+			setPlayingFile(null);
+			setPdfFile(null);
+		}
+	};
+
+	const navigatePreview = useCallback(
+		(step: 1 | -1) => {
+			if (previewContextFiles.length === 0) return;
+
+			const currentFileId = previewFile?.id ?? playingFile?.id ?? pdfFile?.id;
+			if (!currentFileId) return;
+
+			const currentIndex = previewContextFiles.findIndex(
+				(f) => f.id === currentFileId,
+			);
+			if (currentIndex === -1) return;
+
+			const nextIndex =
+				(currentIndex + step + previewContextFiles.length) %
+				previewContextFiles.length;
+			const nextFile = previewContextFiles[nextIndex];
+			if (!nextFile) return;
+
+			setPreviewContextIndex(nextIndex);
+
+			const isMedia = isMediaFile(nextFile.name);
+			const isPdf = isPdfFile(nextFile.name);
+
+			if (isMedia) {
+				setPlayingFile(nextFile);
+				setPreviewFile(null);
+				setPdfFile(null);
+			} else if (isPdf) {
+				setPdfFile(nextFile);
+				setPreviewFile(null);
+				setPlayingFile(null);
+			} else {
+				setPreviewFile(nextFile);
+				setPlayingFile(null);
+				setPdfFile(null);
+			}
+		},
+		[previewContextFiles, previewFile, playingFile, pdfFile],
+	);
+
+	const handleNextPreview = useCallback(() => {
+		navigatePreview(1);
+	}, [navigatePreview]);
+
+	const handlePrevPreview = useCallback(() => {
+		navigatePreview(-1);
+	}, [navigatePreview]);
+
+	const previewNeighborFiles = useCallback(() => {
+		if (previewContextFiles.length === 0) {
+			return {
+				nextFile: null as TelegramFile | null,
+				prevFile: null as TelegramFile | null,
+			};
+		}
+
+		const currentFileId = previewFile?.id ?? playingFile?.id ?? pdfFile?.id;
+		if (!currentFileId) {
+			return {
+				nextFile: null as TelegramFile | null,
+				prevFile: null as TelegramFile | null,
+			};
+		}
+
+		const currentIdx = previewContextFiles.findIndex(
+			(f) => f.id === currentFileId,
+		);
+		if (currentIdx === -1) {
+			return {
+				nextFile: null as TelegramFile | null,
+				prevFile: null as TelegramFile | null,
+			};
+		}
+
+		const nextIdx = (currentIdx + 1) % previewContextFiles.length;
+		const prevIdx =
+			(currentIdx - 1 + previewContextFiles.length) %
+			previewContextFiles.length;
+
+		return {
+			nextFile: previewContextFiles[nextIdx] || null,
+			prevFile: previewContextFiles[prevIdx] || null,
+		};
+	}, [previewContextFiles, previewFile, playingFile, pdfFile]);
+
+	const handleDropOnFolder = async (
+		e: React.DragEvent,
+		targetFolderId: number | null,
+	) => {
+		e.preventDefault();
+		e.stopPropagation();
+
+		const dataTransferFileId = e.dataTransfer.getData(
+			"application/x-telegram-file-id",
+		);
+
+		if (activeFolderId === targetFolderId) return;
+
+		const fileId =
+			internalDragRef.current ||
+			(dataTransferFileId ? parseInt(dataTransferFileId) : null);
+
+		if (fileId) {
+			try {
+				const idsToMove = selectedIds.includes(fileId) ? selectedIds : [fileId];
+
+				await invoke("cmd_move_files", {
+					messageIds: idsToMove,
+					sourceFolderId: activeFolderId,
+					targetFolderId: targetFolderId,
+				});
+
+				queryClient.invalidateQueries({ queryKey: ["files", activeFolderId] });
+
+				if (selectedIds.includes(fileId)) setSelectedIds([]);
+
+				toast.success(`Moved ${idsToMove.length} file(s).`);
+
+				setInternalDragFileId(null);
+			} catch {
+				toast.error(`Failed to move file(s).`);
+			}
+		}
+	};
+
+	const currentFolderName =
+		activeFolderId === null
+			? "Saved Messages"
+			: folders.find((f) => f.id === activeFolderId)?.name || "Folder";
+
+	const handleRootDragOver = (e: React.DragEvent) => {
+		if (internalDragRef.current) {
+			e.preventDefault();
+			e.stopPropagation();
+			e.dataTransfer.dropEffect = "move";
+		}
+	};
+
+	const handleRootDragEnter = (e: React.DragEvent) => {
+		if (internalDragRef.current) {
+			e.preventDefault();
+			e.stopPropagation();
+			e.dataTransfer.dropEffect = "move";
+		}
+	};
+
+	const handleGoogleDriveImport = (token: string, items: any[]) => {
+		const existingNames = new Set(allFiles.map((f: TelegramFile) => f.name));
+		const duplicates = items.filter((item) => existingNames.has(item.name));
+
+		if (duplicates.length > 0) {
+			setPendingGoogleDriveImport({ token, items, duplicates });
+			return;
+		}
+
+		importFiles(token, items);
+	};
+
+	const handleSkipExistingGoogleDriveFiles = () => {
+		if (!pendingGoogleDriveImport) return;
+		const duplicateNames = new Set(
+			pendingGoogleDriveImport.duplicates.map((item) => item.name),
+		);
+		const items = pendingGoogleDriveImport.items.filter(
+			(item) => !duplicateNames.has(item.name),
+		);
+		setPendingGoogleDriveImport(null);
+		if (items.length > 0) {
+			importFiles(pendingGoogleDriveImport.token, items);
+		}
+	};
+
+	const handleReplaceExistingGoogleDriveFiles = () => {
+		if (!pendingGoogleDriveImport) return;
+		const { token, items } = pendingGoogleDriveImport;
+		setPendingGoogleDriveImport(null);
+		importFiles(token, items);
+	};
+
+	const previewNeighbors = previewNeighborFiles();
+
+	return (
+		<div
+			className="flex h-screen w-full overflow-hidden bg-telegram-bg relative"
+			onClick={() => setSelectedIds([])}
+			onDragOver={handleRootDragOver}
+			onDragEnter={handleRootDragEnter}
+		>
+			<ExternalDropBlocker onUploadClick={handleManualUpload} />
+
+			<AnimatePresence>
+				{showMoveModal && (
+					<MoveToFolderModal
+						folders={folders}
+						onClose={() => setShowMoveModal(false)}
+						onSelect={handleBulkMove}
+						activeFolderId={activeFolderId}
+						key="move-modal"
+					/>
+				)}
+				{showGoogleDriveImportModal && (
+					<GoogleDriveImportModal
+						onClose={() => setShowGoogleDriveImportModal(false)}
+						onImport={handleGoogleDriveImport}
+					/>
+				)}
+				{pendingGoogleDriveImport && (
+					<motion.div
+						className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+						initial={{ opacity: 0 }}
+						animate={{ opacity: 1 }}
+						exit={{ opacity: 0 }}
+					>
+						<motion.div
+							className="bg-telegram-surface border border-telegram-border rounded-xl shadow-2xl w-full max-w-md overflow-hidden"
+							initial={{ scale: 0.95, opacity: 0 }}
+							animate={{ scale: 1, opacity: 1 }}
+							exit={{ scale: 0.95, opacity: 0 }}
+						>
+							<div className="p-4 border-b border-telegram-border">
+								<h3 className="text-lg font-medium text-telegram-text">
+									Existing Files Found
+								</h3>
+								<p className="text-sm text-telegram-subtext mt-1">
+									{pendingGoogleDriveImport.duplicates.length} file(s) already
+									exist in this Telegram folder.
+								</p>
+							</div>
+							<div className="p-4 max-h-64 overflow-y-auto space-y-2">
+								{pendingGoogleDriveImport.duplicates.map((item) => (
+									<div
+										key={item.id}
+										className="text-sm text-telegram-subtext bg-telegram-bg border border-telegram-border rounded-lg px-3 py-2 truncate"
+										title={item.name}
+									>
+										{item.name}
+									</div>
+								))}
+							</div>
+							<div className="p-4 border-t border-telegram-border bg-telegram-hover flex justify-end gap-2">
+								<button
+									onClick={() => setPendingGoogleDriveImport(null)}
+									className="px-4 py-2 rounded font-medium text-sm text-telegram-subtext hover:bg-telegram-border transition"
+								>
+									Cancel
+								</button>
+								<button
+									onClick={handleSkipExistingGoogleDriveFiles}
+									className="px-4 py-2 rounded font-medium text-sm text-telegram-text bg-telegram-border hover:bg-telegram-border/80 transition"
+								>
+									Skip Existing
+								</button>
+								<button
+									onClick={handleReplaceExistingGoogleDriveFiles}
+									className="px-4 py-2 bg-telegram-primary hover:bg-telegram-primary/90 text-white rounded font-medium text-sm transition"
+								>
+									Import Anyway
+								</button>
+							</div>
+						</motion.div>
+					</motion.div>
+				)}
+				{playingFile && (
+					<MediaPlayer
+						file={playingFile}
+						onClose={() => setPlayingFile(null)}
+						onNext={handleNextPreview}
+						onPrev={handlePrevPreview}
+						currentIndex={previewContextIndex}
+						totalItems={previewContextFiles.length}
+						activeFolderId={activeFolderId}
+						key="media-player"
+					/>
+				)}
+				{pdfFile && (
+					<PdfViewer
+						file={pdfFile}
+						onClose={() => setPdfFile(null)}
+						onNext={handleNextPreview}
+						onPrev={handlePrevPreview}
+						currentIndex={previewContextIndex}
+						totalItems={previewContextFiles.length}
+						activeFolderId={activeFolderId}
+						key="pdf-viewer"
+					/>
+				)}
+				{isDragging && internalDragFileId === null && (
+					<DragDropOverlay key="drag-drop-overlay" />
+				)}
+			</AnimatePresence>
+
+			<Sidebar
+				folders={folders}
+				activeFolderId={activeFolderId}
+				setActiveFolderId={setActiveFolderId}
+				onDrop={handleDropOnFolder}
+				onDelete={handleFolderDelete}
+				onCreate={handleCreateFolder}
+				isSyncing={isSyncing}
+				isConnected={isConnected}
+				onSync={handleSyncFolders}
+				onLogout={handleLogout}
+				bandwidth={bandwidth || null}
+			/>
+
+			<main
+				className="flex-1 flex flex-col"
+				onClick={(e) => {
+					if (e.target === e.currentTarget) setSelectedIds([]);
+				}}
+			>
+				<TopBar
+					currentFolderName={currentFolderName}
+					selectedIds={selectedIds}
+					onShowMoveModal={() => setShowMoveModal(true)}
+					onBulkDownload={handleBulkDownload}
+					onBulkDelete={handleBulkDelete}
+					onDownloadFolder={handleDownloadFolder}
+					viewMode={viewMode}
+					setViewMode={setViewMode}
+					searchTerm={searchTerm}
+					onSearchChange={setSearchTerm}
+					onOpenGoogleDriveImport={() => setShowGoogleDriveImportModal(true)}
+				/>
+				{searchTerm.length > 2 && (
+					<div className="px-6 pt-4 pb-0">
+						<h2 className="text-sm font-medium text-telegram-subtext">
+							Search Results for{" "}
+							<span className="text-telegram-primary">"{searchTerm}"</span>
+						</h2>
+					</div>
+				)}
+				<FileExplorer
+					files={displayedFiles}
+					loading={isLoading || isSearching}
+					error={error}
+					viewMode={viewMode}
+					selectedIds={selectedIds}
+					activeFolderId={activeFolderId}
+					onFileClick={handleFileClick}
+					onDelete={handleDelete}
+					onDownload={(id, name) => queueDownload(id, name, activeFolderId)}
+					onPreview={handlePreview}
+					onManualUpload={handleManualUpload}
+					onSelectionClear={() => setSelectedIds([])}
+					onDrop={handleDropOnFolder}
+					onDragStart={(fileId) => setInternalDragFileId(fileId)}
+					onDragEnd={() => setTimeout(() => setInternalDragFileId(null), 50)}
+				/>
+			</main>
+
+			{previewFile && (
+				<PreviewModal
+					file={previewFile}
+					activeFolderId={activeFolderId}
+					onClose={() => setPreviewFile(null)}
+					onNext={handleNextPreview}
+					onPrev={handlePrevPreview}
+					currentIndex={previewContextIndex}
+					totalItems={previewContextFiles.length}
+					nextFile={previewNeighbors.nextFile}
+					prevFile={previewNeighbors.prevFile}
+				/>
+			)}
+
+			<UploadQueue
+				items={uploadQueue}
+				onClearFinished={() =>
+					setUploadQueue((q) =>
+						q.filter(
+							(i) =>
+								i.status !== "success" &&
+								i.status !== "error" &&
+								i.status !== "cancelled",
+						),
+					)
+				}
+				onCancelAll={cancelUploads}
+			/>
+			<DownloadQueue
+				items={downloadQueue}
+				onClearFinished={clearDownloads}
+				onCancelAll={cancelDownloads}
+			/>
+			<MigrationQueue
+				items={migrationQueue}
+				onClearFinished={clearFinishedMigrations}
+			/>
+		</div>
+	);
 }

--- a/app/src/components/dashboard/GoogleDriveImportModal.tsx
+++ b/app/src/components/dashboard/GoogleDriveImportModal.tsx
@@ -1,0 +1,454 @@
+import { invoke } from "@tauri-apps/api/core";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { Store } from "@tauri-apps/plugin-store";
+import {
+	AlertCircle,
+	ArrowLeft,
+	Check,
+	CloudRain,
+	Folder,
+	LogOut,
+	X,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import { formatBytes } from "../../utils";
+
+export interface GoogleDriveImportModalProps {
+	onClose: () => void;
+	onImport: (accessToken: string, items: any[]) => void;
+}
+
+export function GoogleDriveImportModal({
+	onClose,
+	onImport,
+}: GoogleDriveImportModalProps) {
+	const [step, setStep] = useState<"config" | "oauth" | "browse">("config");
+	const [clientId, setClientId] = useState("");
+	const [clientSecret, setClientSecret] = useState("");
+	const [accessToken, setAccessToken] = useState("");
+
+	const [folderStack, setFolderStack] = useState<
+		{ id: string; name: string }[]
+	>([{ id: "root", name: "My Drive" }]);
+
+	const rootNavigation = [
+		{ id: "root", name: "My Drive" },
+		{ id: "sharedWithMe", name: "Shared with Me" },
+	];
+
+	const [files, setFiles] = useState<any[]>([]);
+	const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState("");
+
+	useEffect(() => {
+		Store.load("settings.json").then(async (store) => {
+			const savedId = await store.get<string>("gd_client_id");
+			const savedSecret = await store.get<string>("gd_client_secret");
+
+			if (savedId) setClientId(savedId);
+			if (savedSecret) setClientSecret(savedSecret);
+
+			const savedRefreshToken = await store.get<string>("gd_refresh_token");
+			if (savedId && savedSecret && savedRefreshToken) {
+				setLoading(true);
+				try {
+					const res = await invoke<any>("cmd_gd_refresh_token", {
+						clientId: savedId,
+						clientSecret: savedSecret,
+						refreshToken: savedRefreshToken,
+					});
+					const token = res.accessToken ?? res.access_token;
+					if (token) {
+						setAccessToken(token);
+						await loadFiles(token);
+						setStep("browse");
+					}
+				} catch (e) {
+					console.warn("Silent refresh failed:", e);
+				} finally {
+					setLoading(false);
+				}
+			}
+		});
+	}, []);
+
+	const handleConnect = async () => {
+		if (!clientId || !clientSecret) {
+			setError("Please enter Client ID and Secret");
+			return;
+		}
+		setLoading(true);
+		setError("");
+		try {
+			const store = await Store.load("settings.json");
+			await store.set("gd_client_id", clientId);
+			await store.set("gd_client_secret", clientSecret);
+			await store.save();
+
+			const res = await invoke<any>("cmd_gd_auth_url", { clientId });
+			const authUrl = res.authUrl ?? res.auth_url;
+			if (!authUrl) {
+				throw new Error("Google auth URL missing from backend response");
+			}
+
+			setStep("oauth");
+
+			// Start waiting for the redirect BEFORE opening browser
+			const codePromise = invoke<any>("cmd_gd_wait_for_auth_code").catch(
+				(e) => {
+					throw new Error(`Auto-login failed: ${e}`);
+				},
+			);
+
+			await openUrl(authUrl);
+
+			// Wait for browser callback
+			const codeRes = await codePromise;
+			const tokenRes = await invoke<any>("cmd_gd_exchange_token", {
+				clientId,
+				clientSecret,
+				code: codeRes.code,
+			});
+
+			const token = tokenRes.accessToken ?? tokenRes.access_token;
+			const refreshToken = tokenRes.refreshToken ?? tokenRes.refresh_token;
+			if (!token)
+				throw new Error("Google access token missing from backend response");
+
+			if (refreshToken) {
+				await store.set("gd_refresh_token", refreshToken);
+				await store.save();
+			}
+
+			setAccessToken(token);
+			await loadFiles(token);
+			setStep("browse");
+		} catch (e) {
+			setError(String(e));
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	const loadFiles = async (token: string, folderId: string = "root") => {
+		setLoading(true);
+		try {
+			const res = await invoke<any>("cmd_gd_list_files", {
+				accessToken: token,
+				folderId: folderId,
+				pageToken: null,
+			});
+			setFiles(res.files);
+		} catch (e) {
+			setError(String(e));
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	const toggleSelect = (id: string) => {
+		const next = new Set(selectedIds);
+		if (next.has(id)) next.delete(id);
+		else next.add(id);
+		setSelectedIds(next);
+	};
+
+	const toggleSelectAll = () => {
+		const importableFiles = files.filter(
+			(f) => f.mimeType !== "application/vnd.google-apps.folder",
+		);
+		if (
+			selectedIds.size === importableFiles.length &&
+			importableFiles.length > 0
+		) {
+			setSelectedIds(new Set());
+		} else {
+			setSelectedIds(new Set(importableFiles.map((f) => f.id)));
+		}
+	};
+
+	const enterFolder = (id: string, name: string) => {
+		let newStack = [...folderStack, { id, name }];
+		if (id === "root" || id === "sharedWithMe") {
+			newStack = [{ id, name }];
+		}
+		setFolderStack(newStack);
+		setSelectedIds(new Set());
+		loadFiles(accessToken, id);
+	};
+
+	const navigateBack = () => {
+		if (folderStack.length <= 1) return;
+		const newStack = folderStack.slice(0, -1);
+		setFolderStack(newStack);
+		setSelectedIds(new Set());
+		loadFiles(accessToken, newStack[newStack.length - 1].id);
+	};
+
+	const handleImport = () => {
+		const items = files
+			.filter((f) => selectedIds.has(f.id))
+			.map((f) => ({
+				id: f.id,
+				name: f.name,
+				size: f.size ? parseInt(f.size) : undefined,
+			}));
+		onImport(accessToken, items);
+		onClose();
+	};
+
+	const handleLogout = async () => {
+		try {
+			const store = await Store.load("settings.json");
+			await store.delete("gd_refresh_token");
+			await store.save();
+			setAccessToken("");
+			setFiles([]);
+			setSelectedIds(new Set());
+			setFolderStack([{ id: "root", name: "My Drive" }]);
+			setStep("config");
+		} catch (e) {
+			console.error("Failed to logout:", e);
+		}
+	};
+
+	return (
+		<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4 animate-in fade-in">
+			<div className="bg-telegram-surface border border-telegram-border rounded-xl shadow-2xl w-full max-w-2xl flex flex-col max-h-[85vh]">
+				<div className="flex justify-between items-center p-4 border-b border-telegram-border">
+					<div className="flex items-center gap-2">
+						<CloudRain className="w-5 h-5 text-telegram-primary" />
+						<h3 className="text-lg font-medium text-telegram-text">
+							Import from Google Drive
+						</h3>
+					</div>
+					<div className="flex items-center gap-2">
+						{step === "browse" && (
+							<button
+								onClick={handleLogout}
+								title="Disconnect Google Account"
+								className="text-telegram-subtext hover:text-red-400 p-1 rounded-md hover:bg-telegram-hover transition mr-2"
+							>
+								<LogOut className="w-4 h-4" />
+							</button>
+						)}
+						<button
+							onClick={onClose}
+							className="text-telegram-subtext hover:text-telegram-text p-1 rounded-md hover:bg-telegram-hover transition"
+						>
+							<X className="w-5 h-5" />
+						</button>
+					</div>
+				</div>
+
+				<div className="p-6 overflow-y-auto">
+					{error && (
+						<div className="mb-4 p-3 bg-red-500/10 border border-red-500/20 text-red-400 rounded-lg flex items-center gap-2 text-sm">
+							<AlertCircle className="w-4 h-4 flex-shrink-0" />
+							<span>{error}</span>
+						</div>
+					)}
+
+					{step === "config" && (
+						<div className="space-y-4">
+							<p className="text-sm text-telegram-subtext">
+								To access your Google Drive, you need a Google Cloud OAuth
+								Client ID.
+							</p>
+							<div>
+								<label className="block text-xs text-telegram-subtext mb-1">
+									Client ID
+								</label>
+								<input
+									type="text"
+									value={clientId}
+									onChange={(e) => setClientId(e.target.value)}
+									className="w-full bg-telegram-bg border border-telegram-border rounded px-3 py-2 text-sm text-telegram-text focus:outline-none focus:border-telegram-primary"
+									placeholder="...apps.googleusercontent.com"
+								/>
+							</div>
+							<div>
+								<label className="block text-xs text-telegram-subtext mb-1">
+									Client Secret
+								</label>
+								<input
+									type="password"
+									value={clientSecret}
+									onChange={(e) => setClientSecret(e.target.value)}
+									className="w-full bg-telegram-bg border border-telegram-border rounded px-3 py-2 text-sm text-telegram-text focus:outline-none focus:border-telegram-primary"
+									placeholder="GOCSPX-..."
+								/>
+							</div>
+							<button
+								onClick={handleConnect}
+								disabled={loading}
+								className="w-full bg-telegram-primary hover:bg-telegram-primary/90 text-white font-medium py-2 rounded-lg transition disabled:opacity-50"
+							>
+								{loading ? "Connecting..." : "Connect to Google Drive"}
+							</button>
+						</div>
+					)}
+
+					{step === "oauth" && (
+						<div className="flex flex-col items-center justify-center py-12 text-center">
+							<div className="w-16 h-16 border-4 border-telegram-primary/30 border-t-telegram-primary rounded-full animate-spin mb-6"></div>
+							<h4 className="text-xl font-medium text-telegram-text mb-2">
+								Waiting for Authentication
+							</h4>
+							<p className="text-telegram-subtext max-w-md">
+								Your browser should have opened. Please sign in to Google and
+								authorize Telegram Drive. This window will automatically
+								continue once complete.
+							</p>
+						</div>
+					)}
+
+					{step === "browse" && (
+						<div className="space-y-3">
+							<div className="flex items-center gap-2 mb-2">
+								{rootNavigation.map((nav) => (
+									<button
+										key={nav.id}
+										onClick={() => enterFolder(nav.id, nav.name)}
+										className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+											folderStack[0]?.id === nav.id
+												? "bg-telegram-primary text-white"
+												: "bg-telegram-bg text-telegram-subtext hover:text-telegram-text border border-telegram-border"
+										}`}
+									>
+										{nav.name}
+									</button>
+								))}
+							</div>
+
+							<div className="flex items-center justify-between bg-telegram-bg p-2 rounded border border-telegram-border">
+								<div className="flex items-center gap-2 overflow-hidden">
+									{folderStack.length > 1 && (
+										<button
+											onClick={navigateBack}
+											className="p-1 hover:bg-telegram-border rounded text-telegram-subtext hover:text-telegram-text"
+										>
+											<ArrowLeft className="w-4 h-4" />
+										</button>
+									)}
+									<span className="text-sm font-medium text-telegram-text truncate">
+										{folderStack[folderStack.length - 1].name}
+									</span>
+								</div>
+
+								{files.some(
+									(f) => f.mimeType !== "application/vnd.google-apps.folder",
+								) && (
+									<button
+										onClick={toggleSelectAll}
+										className="text-xs font-medium text-telegram-primary hover:bg-telegram-primary/10 px-2 py-1 rounded transition-colors"
+									>
+										{selectedIds.size > 0 &&
+										selectedIds.size ===
+											files.filter(
+												(f) =>
+													f.mimeType !== "application/vnd.google-apps.folder",
+											).length
+											? "Deselect All"
+											: "Select All"}
+									</button>
+								)}
+							</div>
+
+							{loading ? (
+								<div className="py-8 text-center text-telegram-subtext text-sm">
+									Loading files...
+								</div>
+							) : files.length === 0 ? (
+								<div className="py-8 text-center text-telegram-subtext text-sm">
+									No files found in this folder.
+								</div>
+							) : (
+								<div className="space-y-1">
+									{files.map((file) => {
+										const isSelected = selectedIds.has(file.id);
+										const isFolder =
+											file.mimeType === "application/vnd.google-apps.folder";
+										return (
+											<div
+												key={file.id}
+												onClick={() => {
+													if (isFolder) {
+														enterFolder(file.id, file.name);
+													} else {
+														toggleSelect(file.id);
+													}
+												}}
+												className={`flex items-center gap-3 p-2 rounded-lg border cursor-pointer transition-colors ${
+													isSelected
+														? "bg-telegram-primary/10 border-telegram-primary"
+														: isFolder
+															? "bg-telegram-bg border-telegram-border hover:border-telegram-primary/50"
+															: "bg-telegram-surface border-transparent hover:bg-telegram-hover"
+												}`}
+											>
+												<div
+													className={`w-5 h-5 rounded flex items-center justify-center border shrink-0 ${
+														isFolder
+															? "border-transparent bg-transparent"
+															: isSelected
+																? "bg-telegram-primary border-telegram-primary text-white"
+																: "border-telegram-subtext"
+													}`}
+												>
+													{isFolder ? (
+														<Folder
+															className="w-5 h-5 text-blue-400"
+															fill="currentColor"
+															opacity={0.2}
+														/>
+													) : (
+														isSelected && <Check className="w-3 h-3" />
+													)}
+												</div>
+												<div className="flex-1 min-w-0">
+													<div className="text-sm font-medium text-telegram-text truncate">
+														{file.name}
+													</div>
+													{!isFolder && file.size && (
+														<div className="text-xs text-telegram-subtext">
+															{formatBytes(parseInt(file.size))}
+														</div>
+													)}
+												</div>
+											</div>
+										);
+									})}
+								</div>
+							)}
+						</div>
+					)}
+				</div>
+
+				{step === "browse" && (
+					<div className="p-4 border-t border-telegram-border flex justify-between items-center bg-telegram-hover rounded-b-xl">
+						<span className="text-sm text-telegram-subtext">
+							{selectedIds.size} files selected
+						</span>
+						<div className="flex gap-2">
+							<button
+								onClick={onClose}
+								className="px-4 py-2 rounded font-medium text-sm text-telegram-subtext hover:bg-telegram-border transition"
+							>
+								Cancel
+							</button>
+							<button
+								onClick={handleImport}
+								disabled={selectedIds.size === 0}
+								className="px-4 py-2 bg-telegram-primary hover:bg-telegram-primary/90 text-white rounded font-medium text-sm transition disabled:opacity-50"
+							>
+								Import Selected
+							</button>
+						</div>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/app/src/components/dashboard/MigrationQueue.tsx
+++ b/app/src/components/dashboard/MigrationQueue.tsx
@@ -1,0 +1,108 @@
+import { AlertCircle, Check, CloudRain, X } from "lucide-react";
+import type { MigrationItem } from "../../hooks/useGoogleDriveMigration";
+
+interface MigrationQueueProps {
+	items: MigrationItem[];
+	onClearFinished: () => void;
+}
+
+export function MigrationQueue({
+	items,
+	onClearFinished,
+}: MigrationQueueProps) {
+	if (items.length === 0) return null;
+
+	const activeCount = items.filter(
+		(i) => i.status !== "done" && i.status !== "error",
+	).length;
+	const completedCount = items.filter((i) => i.status === "done").length;
+
+	return (
+		<div className="fixed bottom-4 left-4 w-96 bg-telegram-surface border border-telegram-border rounded-xl shadow-2xl overflow-hidden z-[100]">
+			<div className="p-3 border-b border-telegram-border bg-telegram-hover flex justify-between items-center">
+				<div className="flex items-center gap-2">
+					<CloudRain className="w-4 h-4 text-telegram-primary" />
+					<h4 className="text-sm font-medium text-telegram-text">
+						Google Drive Import
+					</h4>
+					{activeCount > 0 && (
+						<span className="text-xs px-1.5 py-0.5 bg-telegram-primary/20 text-telegram-primary rounded-full">
+							{activeCount} active
+						</span>
+					)}
+				</div>
+				<div className="flex gap-2">
+					{completedCount > 0 && (
+						<button
+							onClick={onClearFinished}
+							className="text-xs text-telegram-primary hover:text-telegram-text transition-colors"
+						>
+							Clear Finished
+						</button>
+					)}
+				</div>
+			</div>
+			<div className="max-h-60 overflow-y-auto p-2 space-y-2">
+				{items.map((item) => (
+					<div
+						key={item.id}
+						className="flex flex-col gap-1 p-2 bg-telegram-hover rounded"
+					>
+						<div className="flex items-center gap-3 text-sm">
+							<div className="flex-shrink-0">
+								{item.status === "starting" && (
+									<div className="w-4 h-4 rounded-full border-2 border-yellow-500 border-t-transparent animate-spin" />
+								)}
+								{item.status === "downloading" && (
+									<div className="w-4 h-4 rounded-full border-2 border-blue-500 border-t-transparent animate-spin" />
+								)}
+								{item.status === "uploading" && (
+									<div className="w-4 h-4 rounded-full border-2 border-telegram-primary border-t-transparent animate-spin" />
+								)}
+								{item.status === "done" && (
+									<div className="w-4 h-4 rounded-full bg-green-500/20 flex items-center justify-center">
+										<Check className="w-3 h-3 text-green-500" />
+									</div>
+								)}
+								{item.status === "error" && (
+									<div className="w-4 h-4 rounded-full bg-red-500/20 flex items-center justify-center">
+										<X className="w-3 h-3 text-red-500" />
+									</div>
+								)}
+							</div>
+							<div
+								className="flex-1 truncate text-telegram-subtext"
+								title={item.filename}
+							>
+								{item.filename}
+							</div>
+							{item.status !== "done" && item.status !== "error" && (
+								<div className="text-xs text-telegram-primary font-mono">
+									{item.progress}%
+								</div>
+							)}
+						</div>
+						{item.status !== "done" && item.status !== "error" && (
+							<div className="w-full bg-telegram-border h-1 mt-1 rounded-full overflow-hidden">
+								<div
+									className="bg-telegram-primary h-full rounded-full transition-all duration-300"
+									style={{ width: `${item.progress}%` }}
+								/>
+							</div>
+						)}
+						{item.status === "error" && item.error && (
+							<div className="flex items-center gap-1 text-xs text-red-400 mt-1">
+								<AlertCircle className="w-3 h-3" />
+								<span className="truncate">{item.error}</span>
+							</div>
+						)}
+						<div className="text-[10px] text-telegram-subtext px-7">
+							{item.status === "downloading" && "Fetching from Google Drive..."}
+							{item.status === "uploading" && "Uploading to Telegram..."}
+						</div>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/app/src/components/dashboard/TopBar.tsx
+++ b/app/src/components/dashboard/TopBar.tsx
@@ -1,86 +1,141 @@
-import { HardDrive, LayoutGrid, Sun, Moon } from 'lucide-react';
-import { useTheme } from '../../context/ThemeContext';
+import { CloudDownload, HardDrive, LayoutGrid, Moon, Sun } from "lucide-react";
+import { useTheme } from "../../context/ThemeContext";
 
 interface TopBarProps {
-    currentFolderName: string;
-    selectedIds: number[];
-    onShowMoveModal: () => void;
-    onBulkDownload: () => void;
-    onBulkDelete: () => void;
-    onDownloadFolder: () => void;
-    viewMode: 'grid' | 'list';
-    setViewMode: (mode: 'grid' | 'list') => void;
-    searchTerm: string;
-    onSearchChange: (term: string) => void;
+	currentFolderName: string;
+	selectedIds: number[];
+	onShowMoveModal: () => void;
+	onBulkDownload: () => void;
+	onBulkDelete: () => void;
+	onDownloadFolder: () => void;
+	viewMode: "grid" | "list";
+	setViewMode: (mode: "grid" | "list") => void;
+	searchTerm: string;
+	onSearchChange: (term: string) => void;
+	onOpenGoogleDriveImport: () => void;
 }
 
 export function TopBar({
-    currentFolderName, selectedIds, onShowMoveModal, onBulkDownload, onBulkDelete,
-    onDownloadFolder, viewMode, setViewMode, searchTerm, onSearchChange
+	currentFolderName,
+	selectedIds,
+	onShowMoveModal,
+	onBulkDownload,
+	onBulkDelete,
+	onDownloadFolder,
+	viewMode,
+	setViewMode,
+	searchTerm,
+	onSearchChange,
+	onOpenGoogleDriveImport,
 }: TopBarProps) {
-    const { theme, toggleTheme } = useTheme();
+	const { theme, toggleTheme } = useTheme();
 
-    return (
-        <header className="h-14 border-b border-telegram-border flex items-center px-4 justify-between bg-telegram-surface/80 backdrop-blur-md sticky top-0 z-10" onClick={e => e.stopPropagation()}>
-            <div className="flex items-center gap-4">
-                <div className="flex items-center text-sm breadcrumbs text-telegram-subtext select-none">
-                    <span className="hover:text-telegram-text cursor-pointer transition-colors">Start</span>
-                    <span className="mx-2">/</span>
-                    <span className="text-telegram-text font-medium">{currentFolderName}</span>
-                </div>
-            </div>
+	return (
+		<header
+			className="h-14 border-b border-telegram-border flex items-center px-4 justify-between bg-telegram-surface/80 backdrop-blur-md sticky top-0 z-10"
+			onClick={(e) => e.stopPropagation()}
+		>
+			<div className="flex items-center gap-4">
+				<div className="flex items-center text-sm breadcrumbs text-telegram-subtext select-none">
+					<span className="hover:text-telegram-text cursor-pointer transition-colors">
+						Start
+					</span>
+					<span className="mx-2">/</span>
+					<span className="text-telegram-text font-medium">
+						{currentFolderName}
+					</span>
+				</div>
+			</div>
 
-            <div className="flex-1 max-w-md mx-4">
-                <input
-                    type="text"
-                    placeholder="Search files..."
-                    className="w-full bg-telegram-hover border border-telegram-border rounded-lg px-3 py-1.5 text-sm text-telegram-text placeholder:text-telegram-subtext focus:outline-none focus:border-telegram-primary/50 transition-colors"
-                    value={searchTerm}
-                    onChange={(e) => onSearchChange(e.target.value)}
-                />
-            </div>
+			<div className="flex-1 max-w-md mx-4">
+				<input
+					type="text"
+					placeholder="Search files..."
+					className="w-full bg-telegram-hover border border-telegram-border rounded-lg px-3 py-1.5 text-sm text-telegram-text placeholder:text-telegram-subtext focus:outline-none focus:border-telegram-primary/50 transition-colors"
+					value={searchTerm}
+					onChange={(e) => onSearchChange(e.target.value)}
+				/>
+			</div>
 
-            <div className="flex items-center gap-2">
-                {selectedIds.length > 0 && (
-                    <div className="flex items-center gap-2 mr-4 animate-in fade-in slide-in-from-top-2">
-                        <span className="text-xs text-telegram-subtext mr-2">{selectedIds.length} Selected</span>
-                        <button onClick={onShowMoveModal} className="px-3 py-1.5 bg-telegram-primary/20 hover:bg-telegram-primary/30 text-telegram-primary rounded-md text-xs transition font-medium">Move to...</button>
-                        <button onClick={onBulkDownload} className="px-3 py-1.5 bg-telegram-hover hover:bg-telegram-border rounded-md text-xs text-telegram-text transition">Download Selected</button>
-                        <button onClick={onBulkDelete} className="px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-400 rounded-md text-xs transition">Delete</button>
-                    </div>
-                )}
+			<div className="flex items-center gap-2">
+				{selectedIds.length > 0 && (
+					<div className="flex items-center gap-2 mr-4 animate-in fade-in slide-in-from-top-2">
+						<span className="text-xs text-telegram-subtext mr-2">
+							{selectedIds.length} Selected
+						</span>
+						<button
+							onClick={onShowMoveModal}
+							className="px-3 py-1.5 bg-telegram-primary/20 hover:bg-telegram-primary/30 text-telegram-primary rounded-md text-xs transition font-medium"
+						>
+							Move to...
+						</button>
+						<button
+							onClick={onBulkDownload}
+							className="px-3 py-1.5 bg-telegram-hover hover:bg-telegram-border rounded-md text-xs text-telegram-text transition"
+						>
+							Download Selected
+						</button>
+						<button
+							onClick={onBulkDelete}
+							className="px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-400 rounded-md text-xs transition"
+						>
+							Delete
+						</button>
+					</div>
+				)}
 
-                <button onClick={onDownloadFolder} className="p-2 hover:bg-telegram-hover rounded-md text-telegram-subtext hover:text-telegram-text transition group relative" title="Download Folder">
-                    <HardDrive className="w-5 h-5" />
-                    <span className="absolute -bottom-8 left-1/2 -translate-x-1/2 text-[10px] bg-telegram-surface border border-telegram-border px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-lg">
-                        Download All Files
-                    </span>
-                </button>
+				<button
+					onClick={onOpenGoogleDriveImport}
+					className="p-2 hover:bg-telegram-hover rounded-md text-telegram-subtext hover:text-telegram-text transition group relative"
+					title="Import from Google Drive"
+				>
+					<CloudDownload className="w-5 h-5" />
+					<span className="absolute -bottom-8 left-1/2 -translate-x-1/2 text-[10px] bg-telegram-surface border border-telegram-border px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-lg">
+						Import from Google Drive
+					</span>
+				</button>
 
-                <button
-                    onClick={() => setViewMode(viewMode === 'grid' ? 'list' : 'grid')}
-                    className="p-2 hover:bg-telegram-hover rounded-md text-telegram-subtext hover:text-telegram-text transition relative group"
-                    title="Toggle Layout"
-                >
-                    <LayoutGrid className="w-5 h-5" />
-                    <span className="absolute -bottom-8 left-1/2 -translate-x-1/2 text-[10px] bg-telegram-surface border border-telegram-border px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-lg">
-                        {viewMode === 'grid' ? 'Switch to List' : 'Switch to Grid'}
-                    </span>
-                </button>
+				<button
+					onClick={onDownloadFolder}
+					className="p-2 hover:bg-telegram-hover rounded-md text-telegram-subtext hover:text-telegram-text transition group relative"
+					title="Download Folder"
+				>
+					<HardDrive className="w-5 h-5" />
+					<span className="absolute -bottom-8 left-1/2 -translate-x-1/2 text-[10px] bg-telegram-surface border border-telegram-border px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-lg">
+						Download All Files
+					</span>
+				</button>
 
-                <div className="w-px h-6 bg-telegram-border mx-1"></div>
+				<button
+					onClick={() => setViewMode(viewMode === "grid" ? "list" : "grid")}
+					className="p-2 hover:bg-telegram-hover rounded-md text-telegram-subtext hover:text-telegram-text transition relative group"
+					title="Toggle Layout"
+				>
+					<LayoutGrid className="w-5 h-5" />
+					<span className="absolute -bottom-8 left-1/2 -translate-x-1/2 text-[10px] bg-telegram-surface border border-telegram-border px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-lg">
+						{viewMode === "grid" ? "Switch to List" : "Switch to Grid"}
+					</span>
+				</button>
 
-                <button
-                    onClick={toggleTheme}
-                    className="p-2 hover:bg-telegram-hover rounded-md text-telegram-subtext hover:text-telegram-text transition relative group"
-                    title={theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
-                >
-                    {theme === 'dark' ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
-                    <span className="absolute -bottom-8 left-1/2 -translate-x-1/2 text-[10px] bg-telegram-surface border border-telegram-border px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-lg">
-                        {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
-                    </span>
-                </button>
-            </div>
-        </header>
-    )
+				<div className="w-px h-6 bg-telegram-border mx-1"></div>
+
+				<button
+					onClick={toggleTheme}
+					className="p-2 hover:bg-telegram-hover rounded-md text-telegram-subtext hover:text-telegram-text transition relative group"
+					title={
+						theme === "dark" ? "Switch to Light Mode" : "Switch to Dark Mode"
+					}
+				>
+					{theme === "dark" ? (
+						<Sun className="w-5 h-5" />
+					) : (
+						<Moon className="w-5 h-5" />
+					)}
+					<span className="absolute -bottom-8 left-1/2 -translate-x-1/2 text-[10px] bg-telegram-surface border border-telegram-border px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-lg">
+						{theme === "dark" ? "Light Mode" : "Dark Mode"}
+					</span>
+				</button>
+			</div>
+		</header>
+	);
 }

--- a/app/src/hooks/useGoogleDriveMigration.ts
+++ b/app/src/hooks/useGoogleDriveMigration.ts
@@ -1,0 +1,108 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+export interface GoogleDriveImportItem {
+	id: string;
+	name: string;
+	size?: number;
+}
+
+export interface MigrationItem {
+	id: string;
+	filename: string;
+	status:
+		| "pending"
+		| "starting"
+		| "downloading"
+		| "uploading"
+		| "done"
+		| "error";
+	progress: number;
+	error?: string;
+}
+
+interface MigrationPayload {
+	id: string;
+	filename: string;
+	status: string;
+	percent: number;
+	error: string | null;
+}
+
+export function useGoogleDriveMigration(activeFolderId: number | null) {
+	const queryClient = useQueryClient();
+	const [migrationQueue, setMigrationQueue] = useState<MigrationItem[]>([]);
+
+	useEffect(() => {
+		let unlisten: UnlistenFn | undefined;
+		listen<MigrationPayload>("migration-progress", (event) => {
+			const payload = event.payload;
+			setMigrationQueue((q) => {
+				const existing = q.find((i) => i.id === payload.id);
+				if (existing) {
+					return q.map((i) =>
+						i.id === payload.id
+							? {
+									...i,
+									status: payload.status as MigrationItem["status"],
+									progress: payload.percent,
+									error: payload.error || undefined,
+								}
+							: i,
+					);
+				}
+
+				return [
+					...q,
+					{
+						id: payload.id,
+						filename: payload.filename,
+						status: payload.status as MigrationItem["status"],
+						progress: payload.percent,
+						error: payload.error || undefined,
+					},
+				];
+			});
+
+			if (payload.status === "done") {
+				queryClient.invalidateQueries({ queryKey: ["files", activeFolderId] });
+			}
+		}).then((fn) => {
+			unlisten = fn;
+		});
+		return () => {
+			unlisten?.();
+		};
+	}, [activeFolderId, queryClient]);
+
+	const importFiles = async (
+		accessToken: string,
+		items: GoogleDriveImportItem[],
+	) => {
+		try {
+			await invoke("cmd_gd_import_files", {
+				accessToken,
+				items,
+				folderId: activeFolderId,
+			});
+			toast.success(`Migration completed for ${items.length} files`);
+		} catch (e) {
+			toast.error(`Migration failed: ${e}`);
+		}
+	};
+
+	const clearFinished = () => {
+		setMigrationQueue((q) =>
+			q.filter((i) => i.status !== "done" && i.status !== "error"),
+		);
+	};
+
+	return {
+		migrationQueue,
+		importFiles,
+		clearFinished,
+	};
+}


### PR DESCRIPTION
# Google Drive Import

this PR adds the ability to import files directly from Google Drive into Telegram Drive folders.

what changed:

- added a new top bar button to open the drive import flow
- implemented google oauth login (opens browser, grabs token, saves refresh token)
- added a file explorer modal to browse your drive and select files/folders (supports shared drives too)
- added a migration queue ui to track the progress of files being downloaded from google and uploaded to telegram
- checks for duplicate files in the target folder before importing and asks if you want to skip or overwrite
- handles google docs/sheets export automatically before uploading

all streaming is done directly in the rust backend, it just downloads the chunks and passes them straight to telegram without touching the local disk.
