### PR TITLE
Resolve PDF and media streaming port and added Accept-Ranges

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -309,7 +309,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "actix-cors",
  "actix-rt",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "1.1.10"
+version = "1.1.11"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/src/server.rs
+++ b/app/src-tauri/src/server.rs
@@ -102,6 +102,7 @@ async fn stream_media(
                                 return HttpResponse::Ok()
                                     .insert_header(("Content-Type", mime)) 
                                     .insert_header(("Content-Length", size.to_string()))
+                                    .insert_header(("Accept-Ranges", "bytes"))
                                     .insert_header(("Cache-Control", "private, max-age=120"))
                                     .streaming(stream);
                             } else {

--- a/app/src/components/dashboard/MediaPlayer.tsx
+++ b/app/src/components/dashboard/MediaPlayer.tsx
@@ -23,7 +23,7 @@ export function MediaPlayer({ file, onClose, onNext, onPrev, currentIndex, total
 
     const folderIdParam = activeFolderId !== null ? activeFolderId.toString() : 'home';
     const streamUrl = streamToken
-        ? `http://localhost:14200/stream/${folderIdParam}/${file.id}?token=${streamToken}`
+        ? `http://localhost:14201/stream/${folderIdParam}/${file.id}?token=${streamToken}`
         : null;
 
     const isVideo = isVideoFile(file.name);

--- a/app/src/components/dashboard/PdfViewer.tsx
+++ b/app/src/components/dashboard/PdfViewer.tsx
@@ -49,7 +49,7 @@ export function PdfViewer({ file, onClose, onNext, onPrev, currentIndex, totalIt
         setNumPages(0);
 
         const folderIdParam = activeFolderId !== null ? activeFolderId.toString() : 'home';
-        const streamUrl = `http://localhost:14200/stream/${folderIdParam}/${file.id}?token=${streamToken}`;
+        const streamUrl = `http://localhost:14201/stream/${folderIdParam}/${file.id}?token=${streamToken}`;
 
         const loadingTask = pdfjsLib.getDocument(streamUrl);
 


### PR DESCRIPTION
Resolve PDF and media streaming port and added Accept-Ranges: bytes header to indicate support for partial content requests, enabling client-side seeking in media playback.