### PR TITLE
Add support for Telegram text messages as files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,28 @@
-# Telegram Drive 
+# Telegram Drive
 
-**Telegram Drive** is an open-source, cross-platform desktop application that turns your Telegram account into an unlimited, secure cloud storage drive. Built with **Tauri**, **Rust**, and **React**.
+Telegram Drive is an open-source desktop app that turns your Telegram account into a cloud storage drive. It is built with Tauri, Rust, React, TypeScript, and Vite.
 
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
-![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20MacOS%20%7C%20Linux-blue)
-
+![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-blue)
 
 ![Auth Screen](screenshots/AuthScreen.png)
 
-##  What is Telegram Drive?
+## What It Does
 
-Telegram Drive leverages the Telegram API to allow you to upload, organize, and manage files directly on Telegram's servers. It treats your "Saved Messages" and created Channels as folders, giving you a familiar file explorer interface for your Telegram cloud.
+Telegram Drive uses the Telegram API to upload, organize, preview, stream, and manage files through your Telegram account. Files stay tied to your Telegram account, and the app runs locally on your machine.
 
-###  Key Features
+## Features
 
-*   **Unlimited Cloud Storage**: Utilizing Telegram's generous cloud infrastructure.
-*   **High Performance Grid**: Virtual scrolling handles folders with thousands of files instantly.
-*   **Auto-Updates**: Seamless updates for Windows, macOS, and Linux.
-*   **Media Streaming**: Stream video and audio files directly without downloading.
-*   **PDF Viewer:** Built-in PDF support with infinite scrolling for seamless document reading.
-*   **Drag & Drop**: Intuitive drag-and-drop upload and file management.
-*   **Thumbnail Previews**: Inline thumbnails for images and media files.
-*   **Folder Management**: Create "Folders" (private Telegram Channels) to organize content.
-*   **Privacy Focused**: API keys and data stay local. No third-party servers.
-*   **Cross-Platform**: Native apps for macOS (Intel/ARM), Windows, and Linux.
+- Unlimited Telegram-backed cloud storage
+- Folder management using Telegram channels
+- Drag-and-drop uploads
+- File previews, thumbnails, audio playback, and video playback
+- PDF viewing
+- High-performance grid for large folders
+- Local-first privacy model
+- Cross-platform desktop support through Tauri
 
-##  Screenshots
+## Screenshots
 
 | Dashboard | File Preview |
 |-----------|--------------|
@@ -40,107 +37,266 @@ Telegram Drive leverages the Telegram API to allow you to upload, organize, and 
 | ![Audio Playback](screenshots/AudioPlayback.png) | ![Video Playback](screenshots/VideoPlayback.png) |
 
 | Auth Code Screen | Upload Example |
-|------------------|-------------|
+|------------------|----------------|
 | ![Auth Code Screen](screenshots/AuthCodeScreen.png) | ![Upload Example](screenshots/UploadExample.png) |
 
 | Folder Creation | Folder List View |
 |-----------------|------------------|
 | ![Folder Creation](screenshots/FolderCreation.png) | ![Folder List View](screenshots/FolderListView.png) |
 
-##  Tech Stack
+## Project Structure
 
-*   **Frontend**: React, TypeScript, TailwindCSS, Framer Motion
-*   **Backend**: Rust (Tauri), Grammers (Telegram Client)
-*   **Build Tool**: Vite
+```text
+Telegram-Drive/
+|-- app/                  # Tauri, React, and Rust application
+|   |-- src/              # React frontend
+|   |-- src-tauri/        # Rust/Tauri backend
+|   |-- package.json      # npm scripts and frontend dependencies
+|   `-- vite.config.ts    # Vite development config
+|-- screenshots/          # README images
+`-- README.md
+```
 
+## Requirements
 
-##  Getting Started
+Install these before running the project.
 
-### Prerequisites
+### 1. Node.js
 
-*   **Node.js (v18+)**: [Download here](https://nodejs.org/)
-*   **Rust (latest stable)**: Required to compile the Tauri backend. Install via [rustup](https://rustup.rs/):
-    *   **macOS/Linux:** `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
-    *   **Windows:** Download and run `rustup-init.exe` from [rustup.rs](https://rustup.rs/)
-    *   *Verify installation:* run `rustc --version` and `cargo --version` in your terminal.
-*   **OS-Specific Build Tools for Tauri**: 
-    *   **macOS:** Xcode Command Line Tools (`xcode-select --install`).
-    *   **Linux (Ubuntu/Debian):** `sudo apt update && sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev`
-    *   **Windows (CRITICAL):** You **must** install the [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/). During installation, select the **"Desktop development with C++"** workload. Without this, you will get a `linker 'link.exe' not found` error.
-    *   **Windows (WebView2):** Windows 10/11 users usually have this pre-installed. If not, download the [WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section).
-    *   *Reference:* See the official [Tauri v2 Prerequisites Guide](https://v2.tauri.app/start/prerequisites/) for detailed instructions.
-*   **Telegram API Credentials**: You need your own API ID and API Hash to communicate with Telegram's servers.
-    1. Log into [my.telegram.org](https://my.telegram.org).
-    2. Go to "API development tools" and create a new application to get your `api_id` and `api_hash`.
+Install Node.js 18 or newer.
 
-> [!NOTE]  
-> **First-run Compile Time:** The initial build (`npm run tauri dev` or `npm run tauri build`) will download and compile over 300 Rust crates. This process can take **5 to 15 minutes** depending on your hardware. Subsequent builds will be much faster.
+- Download: https://nodejs.org/
+- Verify:
 
-> [!TIP]
-> **NPM Vulnerabilities:** You may see vulnerability warnings during `npm install`. These are usually related to build tools and dev dependencies. You can optionally run `npm audit fix`, but it is not strictly required to run the app.
+```bash
+node --version
+npm --version
+```
 
-### Installation
+### 2. Rust and Cargo
 
-1.  **Clone the repository**
-    ```bash
-    git clone https://github.com/caamer20/Telegram-Drive.git
-    cd Telegram-Drive
-    ```
+Tauri needs Rust and Cargo to compile the desktop backend.
 
-2.  **Install Dependencies**
-    ```bash
-    cd app
-    npm install
-    ```
+#### Windows
 
-3.  **Run in Development Mode**
-    ```bash
-    npm run tauri dev
-    ```
+Install Rustup:
 
-4.  **Build/Compile**
-    ```bash
-    npm run tauri build
-    ```
+```powershell
+winget install --id Rustlang.Rustup -e
+```
 
-##  Open Source & License
+Or download `rustup-init.exe` from https://rustup.rs/.
 
-This project is **Free and Open Source Software**. You are free to use, modify, and distribute it.
+After installing Rust, close your terminal and open a new one. Then verify:
 
-Licensed under the **MIT License**.
+```powershell
+rustc --version
+cargo --version
+```
 
----
-*Disclaimer: This application is not affiliated with Telegram FZ-LLC. Use responsibly and in accordance with Telegram's Terms of Service.*
+If `cargo` is still not found, make sure this folder is in your PATH:
 
-If you're looking for a version of this app that's optimized for VPNs check out this repo:
+```text
+%USERPROFILE%\.cargo\bin
+```
+
+#### macOS and Linux
+
+Install Rustup:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Restart your terminal, then verify:
+
+```bash
+rustc --version
+cargo --version
+```
+
+### 3. Tauri System Dependencies
+
+Tauri also needs native build tools for your operating system.
+
+#### Windows
+
+Install Visual Studio Build Tools:
+
+https://visualstudio.microsoft.com/visual-cpp-build-tools/
+
+During installation, select:
+
+- Desktop development with C++
+- MSVC build tools
+- Windows SDK
+
+Windows 10 and Windows 11 usually already include WebView2. If the app complains about WebView2, install the WebView2 Runtime:
+
+https://developer.microsoft.com/en-us/microsoft-edge/webview2/
+
+#### macOS
+
+Install Xcode Command Line Tools:
+
+```bash
+xcode-select --install
+```
+
+#### Ubuntu/Debian Linux
+
+Install Tauri's Linux dependencies:
+
+```bash
+sudo apt update
+sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
+```
+
+For other Linux distributions, check the Tauri v2 prerequisites guide:
+
+https://v2.tauri.app/start/prerequisites/
+
+### 4. Telegram API Credentials
+
+You need your own Telegram API ID and API hash.
+
+1. Go to https://my.telegram.org/.
+2. Log in with your Telegram account.
+3. Open API development tools.
+4. Create an application.
+5. Save the `api_id` and `api_hash`.
+6. Enter them in Telegram Drive when the app asks for them.
+
+## Run the Project
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/caamer20/Telegram-Drive.git
+cd Telegram-Drive
+```
+
+### 2. Install App Dependencies
+
+```bash
+cd app
+npm install
+```
+
+### 3. Start the Desktop App in Development Mode
+
+```bash
+npm run tauri dev
+```
+
+The first run can take several minutes because Cargo downloads and compiles the Rust dependencies. Later runs are faster.
+
+This command starts the Vite frontend and opens the Tauri desktop window.
+
+## Build the App
+
+From the `app` folder, run:
+
+```bash
+npm run tauri build
+```
+
+The built installer or application bundle will be created inside:
+
+```text
+app/src-tauri/target/release/bundle/
+```
+
+## Useful Commands
+
+Run these from the `app` folder.
+
+```bash
+npm run dev
+```
+
+Starts only the Vite frontend. This is useful for frontend-only work, but it does not run the full desktop app.
+
+```bash
+npm run build
+```
+
+Builds the frontend with TypeScript and Vite.
+
+```bash
+npm run tauri dev
+```
+
+Runs the full Tauri desktop app in development mode.
+
+```bash
+npm run tauri build
+```
+
+Builds the production desktop app.
+
+## Troubleshooting
+
+### `cargo metadata` or `program not found`
+
+This means Cargo is not installed or not available in your terminal PATH.
+
+Fix:
+
+1. Install Rustup.
+2. Close the terminal.
+3. Open a new terminal.
+4. Run:
+
+```bash
+cargo --version
+```
+
+Then try again:
+
+```bash
+npm run tauri dev
+```
+
+### `link.exe not found` on Windows
+
+Install Visual Studio Build Tools and select the Desktop development with C++ workload.
+
+### WebView2 Error on Windows
+
+Install the Microsoft Edge WebView2 Runtime:
+
+https://developer.microsoft.com/en-us/microsoft-edge/webview2/
+
+### First Run Is Slow
+
+That is normal. The first Tauri run downloads and compiles Rust crates. It can take 5 to 15 minutes depending on your computer and internet connection.
+
+### npm Audit Warnings
+
+You may see npm vulnerability warnings after `npm install`. They usually come from development dependencies. They do not necessarily stop the app from running.
+
+## Tech Stack
+
+- React
+- TypeScript
+- Vite
+- Tauri v2
+- Rust
+- Grammers Telegram client
+- Tailwind CSS
+- Framer Motion
+
+## License
+
+This project is released under the MIT License.
+
+## Disclaimer
+
+This application is not affiliated with Telegram FZ-LLC. Use it responsibly and follow Telegram's Terms of Service.
+
+## Related Project
+
+For a VPN-optimized version, see:
+
 https://github.com/caamer20/Telegram-Drive-ForVPNs
-
-<div align="center">
-  <!-- PayPal -->
-  <div style="margin: 15px 0;">
-    <a href="https://www.paypal.me/Caamer20">
-      <img src="https://raw.githubusercontent.com/stefan-niedermann/paypal-donate-button/master/paypal-donate-button.png" alt="Donate with PayPal" width="200">
-    </a>
-    <div style="font-size: 14px; margin-top: 8px;">paypal.me/Caamer20</div>
-  </div>
-
-  <!-- Litecoin -->
-  <div style="margin: 15px 0;">
-    <a href="litecoin:ltc1q6wkr5ac4u0pxx4hx7xgwn0gsaku25ws0df73rp">
-      <img src="https://img.shields.io/badge/Donate-LTC-345D9D?style=for-the-badge&logo=litecoin&logoColor=white" alt="Donate LTC">
-    </a>
-    <div style="font-family: monospace; font-size: 13px; margin-top: 8px; word-break: break-all;">
-      ltc1q6wkr5ac4u0pxx4hx7xgwn0gsaku25ws0df73rp
-    </div>
-  </div>
-
-  <!-- Bitcoin -->
-  <div style="margin: 15px 0;">
-    <a href="bitcoin:bc1q5pt7m2fk6w0dzsnf6vvd5k6nw5k44785286ujy">
-      <img src="https://img.shields.io/badge/Donate-BTC-F7931A?style=for-the-badge&logo=bitcoin&logoColor=white" alt="Donate BTC">
-    </a>
-    <div style="font-family: monospace; font-size: 13px; margin-top: 8px; word-break: break-all;">
-      bc1q5pt7m2fk6w0dzsnf6vvd5k6nw5k44785286ujy
-    </div>
-  </div>
-</div>

--- a/app/README.md
+++ b/app/README.md
@@ -1,7 +1,21 @@
-# Tauri + React + Typescript
+# Telegram Drive App
 
-This template should help get you started developing with Tauri, React and Typescript in Vite.
+This folder contains the Tauri desktop app.
 
-## Recommended IDE Setup
+## Run Locally
 
-- [VS Code](https://code.visualstudio.com/) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
+From this folder:
+
+```bash
+npm install
+npm run tauri dev
+```
+
+If `npm run tauri dev` says Cargo is missing, install Rust from https://rustup.rs/, restart your terminal, and verify:
+
+```bash
+cargo --version
+rustc --version
+```
+
+For the full setup guide, see the root `README.md`.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "1.1.1",
+  "version": "1.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "1.1.1",
+      "version": "1.1.8",
       "dependencies": {
         "@tanstack/react-query": "^5.90.17",
         "@tanstack/react-virtual": "^3.13.18",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "1.1.1",
+  "version": "1.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "1.1.1",
+      "version": "1.1.8",
       "dependencies": {
         "@tanstack/react-query": "^5.90.17",
         "@tanstack/react-virtual": "^3.13.18",
@@ -19,6 +19,7 @@
         "framer-motion": "^12.26.2",
         "lucide-react": "^0.562.0",
         "pdfjs-dist": "^5.6.205",
+        "qrcode.react": "^4.2.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "sonner": "^2.0.7"
@@ -2883,6 +2884,15 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/react": {
       "version": "19.2.3",

--- a/app/package.json
+++ b/app/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "pretauri": "node scripts/check-tauri-prereqs.mjs",
     "tauri": "tauri"
   },
   "dependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -21,6 +21,7 @@
     "framer-motion": "^12.26.2",
     "lucide-react": "^0.562.0",
     "pdfjs-dist": "^5.6.205",
+    "qrcode.react": "^4.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "sonner": "^2.0.7"

--- a/app/scripts/check-tauri-prereqs.mjs
+++ b/app/scripts/check-tauri-prereqs.mjs
@@ -1,0 +1,39 @@
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+
+function hasCommand(command, args = ["--version"]) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    shell: process.platform === "win32",
+    stdio: "pipe",
+  });
+
+  return result.status === 0;
+}
+
+if (!hasCommand("cargo")) {
+  const isWindows = process.platform === "win32";
+
+  console.error("\nMissing Rust/Cargo.");
+  console.error("Tauri needs Cargo to compile the Rust backend before it can run.");
+  console.error("");
+
+  if (isWindows) {
+    console.error("Install Rust with one of these options:");
+    console.error("  winget install --id Rustlang.Rustup -e");
+    console.error("  or download rustup-init.exe from https://rustup.rs/");
+    console.error("");
+    console.error("After installing, close this terminal, open a new one, then run:");
+    console.error("  cargo --version");
+    console.error("  npm run tauri dev");
+    console.error("");
+    console.error("If Cargo is already installed, add this folder to PATH:");
+    console.error("  %USERPROFILE%\\.cargo\\bin");
+  } else {
+    console.error("Install Rust from https://rustup.rs/, restart your shell, then run:");
+    console.error("  cargo --version");
+    console.error("  npm run tauri dev");
+  }
+
+  process.exit(1);
+}

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -208,6 +208,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +226,21 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm-siv"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "polyval",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -314,6 +339,8 @@ dependencies = [
  "actix-cors",
  "actix-rt",
  "actix-web",
+ "aes-gcm-siv",
+ "argon2",
  "async-stream",
  "base64 0.21.7",
  "chrono",
@@ -323,10 +350,15 @@ dependencies = [
  "grammers-mtsender",
  "grammers-session",
  "grammers-tl-types",
+ "hex",
+ "jsonwebtoken",
  "log",
+ "once_cell",
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "sha2",
+ "sqlite",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -337,7 +369,9 @@ dependencies = [
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
+ "time",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -347,6 +381,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
 ]
 
 [[package]]
@@ -550,6 +596,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +614,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -944,6 +1005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1680,8 +1742,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2147,7 +2211,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -2501,6 +2565,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2829,9 +2908,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -3139,6 +3218,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3266,6 +3351,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3279,6 +3375,16 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -3488,6 +3594,18 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -4384,6 +4502,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.17",
+ "time",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5135,9 +5265,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -5150,15 +5280,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5513,6 +5643,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -43,4 +43,12 @@ async-stream = "0.3"
 actix-rt = "2"
 tauri-plugin-process = "2.3.1"
 rand = "0.8"
-
+argon2 = "0.5"
+jsonwebtoken = "9"
+uuid = { version = "1", features = ["v4", "serde"] }
+time = { version = "0.3", features = ["serde", "formatting", "parsing", "macros"] }
+sha2 = "0.10"
+hex = "0.4"
+once_cell = "1"
+aes-gcm-siv = "0.11"
+sqlite = "0.37"

--- a/app/src-tauri/src/commands/fs.rs
+++ b/app/src-tauri/src/commands/fs.rs
@@ -5,9 +5,11 @@ use grammers_tl_types as tl;
 use crate::TelegramState;
 use crate::models::{FolderMetadata, FileMetadata};
 use crate::bandwidth::BandwidthManager;
-use crate::commands::utils::{resolve_peer, map_error};
+use crate::commands::utils::{resolve_peer, resolve_peer_ref, map_error};
 
 const TEXT_MESSAGE_PREVIEW_CHARS: usize = 32;
+const TEXT_MESSAGES_FILE_ID: i32 = -1;
+const TEXT_MESSAGES_FILE_NAME: &str = "Text messages.txt";
 
 fn text_message_name(message_id: i32, text: &str) -> String {
     let mut preview = text
@@ -36,6 +38,28 @@ fn text_message_name(message_id: i32, text: &str) -> String {
     }
 
     format!("{}-{}.txt", preview, message_id)
+}
+
+struct TextMessageEntry {
+    id: i32,
+    date: String,
+    text: String,
+}
+
+fn format_text_messages(entries: &[TextMessageEntry]) -> String {
+    entries
+        .iter()
+        .rev()
+        .map(|entry| {
+            format!(
+                "============================================================\nMESSAGE #{}\nDATE: {}\n============================================================\n{}",
+                entry.id,
+                entry.date,
+                entry.text
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n\n")
 }
 
 #[tauri::command]
@@ -182,9 +206,9 @@ pub async fn cmd_upload_file(
         
     let message = InputMessage::new().text("").file(uploaded_file);
 
-    let peer = resolve_peer(&client, folder_id, &state.peer_cache).await?;
+    let peer = resolve_peer_ref(&client, folder_id, &state.peer_cache).await?;
     
-    client.send_message(&peer, message).await.map_err(map_error)?;
+    client.send_message(peer, message).await.map_err(map_error)?;
     
     bw_state.add_up(size);
 
@@ -209,8 +233,8 @@ pub async fn cmd_delete_file(
     }
     let client = client_opt.unwrap();
 
-    let peer = resolve_peer(&client, folder_id, &state.peer_cache).await?;
-    client.delete_messages(&peer, &[message_id]).await.map_err(|e| e.to_string())?;
+    let peer = resolve_peer_ref(&client, folder_id, &state.peer_cache).await?;
+    client.delete_messages(peer, &[message_id]).await.map_err(|e| e.to_string())?;
     Ok(true)
 }
 
@@ -234,10 +258,43 @@ pub async fn cmd_download_file(
     }
     let client = client_opt.unwrap();
     
-    let peer = resolve_peer(&client, folder_id, &state.peer_cache).await?;
+    let peer = resolve_peer_ref(&client, folder_id, &state.peer_cache).await?;
+
+    if message_id == TEXT_MESSAGES_FILE_ID {
+        let mut text_messages = Vec::new();
+        let mut msgs = client.iter_messages(peer);
+        while let Some(msg) = msgs.next().await.map_err(|e| e.to_string())? {
+            if msg.media().is_none() {
+                let text = msg.text().trim();
+                if !text.is_empty() {
+                    text_messages.push(TextMessageEntry {
+                        id: msg.id(),
+                        date: msg.date().to_string(),
+                        text: text.to_string(),
+                    });
+                }
+            }
+        }
+
+        if text_messages.is_empty() {
+            return Err("No text messages found".to_string());
+        }
+
+        let content = format_text_messages(&text_messages);
+        bw_state.can_transfer(content.len() as u64)?;
+        std::fs::write(&save_path, content.as_bytes()).map_err(|e| e.to_string())?;
+        bw_state.add_down(content.len() as u64);
+
+        if !tid.is_empty() {
+            let _ = app_handle.emit("download-progress", ProgressPayload { id: tid, percent: 100 });
+        }
+
+        return Ok("Download successful".to_string());
+    }
 
     // Use get_messages_by_id for efficient message lookup (same as server.rs)
-    let messages = client.get_messages_by_id(&peer, &[message_id]).await.map_err(|e| e.to_string())?;
+    let peer = resolve_peer_ref(&client, folder_id, &state.peer_cache).await?;
+    let messages = client.get_messages_by_id(peer, &[message_id]).await.map_err(|e| e.to_string())?;
     
     let msg = messages.into_iter()
         .flatten()
@@ -321,15 +378,16 @@ pub async fn cmd_move_files(
     }
     let client = client_opt.unwrap();
 
-    let source_peer = resolve_peer(&client, source_folder_id, &state.peer_cache).await?;
-    let target_peer = resolve_peer(&client, target_folder_id, &state.peer_cache).await?;
+    let source_peer = resolve_peer_ref(&client, source_folder_id, &state.peer_cache).await?;
+    let target_peer = resolve_peer_ref(&client, target_folder_id, &state.peer_cache).await?;
 
-    match client.forward_messages(&target_peer, &message_ids, &source_peer).await {
+    match client.forward_messages(target_peer, &message_ids, source_peer).await {
         Ok(_) => {},
         Err(e) => return Err(format!("Forward failed: {}", e)),
     }
     
-    match client.delete_messages(&source_peer, &message_ids).await {
+    let source_peer = resolve_peer_ref(&client, source_folder_id, &state.peer_cache).await?;
+    match client.delete_messages(source_peer, &message_ids).await {
         Ok(_) => {},
         Err(e) => return Err(format!("Delete original failed: {}", e)),
     }
@@ -350,9 +408,10 @@ pub async fn cmd_get_files(
     let client = client_opt.unwrap();
     let mut files = Vec::new();
     
-    let peer = resolve_peer(&client, folder_id, &state.peer_cache).await?;
+    let peer = resolve_peer_ref(&client, folder_id, &state.peer_cache).await?;
 
-    let mut msgs = client.iter_messages(&peer);
+    let mut msgs = client.iter_messages(peer);
+    let mut text_messages = Vec::new();
     while let Some(msg) = msgs.next().await.map_err(|e| e.to_string())? {
         if let Some(doc) = msg.media() {
             let (name, size, mime, ext) = match doc {
@@ -380,19 +439,33 @@ pub async fn cmd_get_files(
         } else {
             let text = msg.text().trim();
             if !text.is_empty() {
-                files.push(FileMetadata {
-                    id: msg.id() as i64,
-                    folder_id,
-                    name: text_message_name(msg.id(), text),
-                    size: text.len() as u64,
-                    mime_type: Some("text/plain".into()),
-                    file_ext: Some("txt".into()),
-                    created_at: msg.date().to_string(),
-                    icon_type: "file".into(),
-                    text_content: Some(text.to_string()),
+                text_messages.push(TextMessageEntry {
+                    id: msg.id(),
+                    date: msg.date().to_string(),
+                    text: text.to_string(),
                 });
             }
         }
+    }
+
+    if !text_messages.is_empty() {
+        let content = format_text_messages(&text_messages);
+        let created_at = text_messages
+            .first()
+            .map(|entry| entry.date.clone())
+            .unwrap_or_default();
+
+        files.push(FileMetadata {
+            id: TEXT_MESSAGES_FILE_ID as i64,
+            folder_id,
+            name: TEXT_MESSAGES_FILE_NAME.to_string(),
+            size: content.len() as u64,
+            mime_type: Some("text/plain".into()),
+            file_ext: Some("txt".into()),
+            created_at,
+            icon_type: "file".into(),
+            text_content: Some(content),
+        });
     }
 
     Ok(files)

--- a/app/src-tauri/src/commands/fs.rs
+++ b/app/src-tauri/src/commands/fs.rs
@@ -7,6 +7,37 @@ use crate::models::{FolderMetadata, FileMetadata};
 use crate::bandwidth::BandwidthManager;
 use crate::commands::utils::{resolve_peer, map_error};
 
+const TEXT_MESSAGE_PREVIEW_CHARS: usize = 32;
+
+fn text_message_name(message_id: i32, text: &str) -> String {
+    let mut preview = text
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or("Text message")
+        .trim()
+        .chars()
+        .take(TEXT_MESSAGE_PREVIEW_CHARS)
+        .collect::<String>();
+
+    preview = preview
+        .chars()
+        .map(|c| match c {
+            '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*' => '_',
+            c if c.is_control() => ' ',
+            c => c,
+        })
+        .collect::<String>()
+        .trim()
+        .trim_matches('.')
+        .to_string();
+
+    if preview.is_empty() {
+        preview = "Text message".to_string();
+    }
+
+    format!("{}-{}.txt", preview, message_id)
+}
+
 #[tauri::command]
 pub async fn cmd_create_folder(
     name: String,
@@ -213,8 +244,23 @@ pub async fn cmd_download_file(
         .next()
         .ok_or_else(|| "Message not found".to_string())?;
 
-    let media = msg.media()
-        .ok_or_else(|| "No media in message".to_string())?;
+    let text = msg.text().to_string();
+
+    let media = match msg.media() {
+        Some(media) => media,
+        None if !text.trim().is_empty() => {
+            bw_state.can_transfer(text.len() as u64)?;
+            std::fs::write(&save_path, text.as_bytes()).map_err(|e| e.to_string())?;
+            bw_state.add_down(text.len() as u64);
+
+            if !tid.is_empty() {
+                let _ = app_handle.emit("download-progress", ProgressPayload { id: tid, percent: 100 });
+            }
+
+            return Ok("Download successful".to_string());
+        },
+        None => return Err("No media or text in message".to_string()),
+    };
 
     let total_size = match &media {
         Media::Document(d) => d.size() as u64,
@@ -321,8 +367,31 @@ pub async fn cmd_get_files(
                 _ => ("Unknown".to_string(), 0, None, None),
             };
             files.push(FileMetadata {
-                id: msg.id() as i64, folder_id, name, size: size as u64, mime_type: mime, file_ext: ext, created_at: msg.date().to_string(), icon_type: "file".into()
+                id: msg.id() as i64,
+                folder_id,
+                name,
+                size: size as u64,
+                mime_type: mime,
+                file_ext: ext,
+                created_at: msg.date().to_string(),
+                icon_type: "file".into(),
+                text_content: None,
             });
+        } else {
+            let text = msg.text().trim();
+            if !text.is_empty() {
+                files.push(FileMetadata {
+                    id: msg.id() as i64,
+                    folder_id,
+                    name: text_message_name(msg.id(), text),
+                    size: text.len() as u64,
+                    mime_type: Some("text/plain".into()),
+                    file_ext: Some("txt".into()),
+                    created_at: msg.date().to_string(),
+                    icon_type: "file".into(),
+                    text_content: Some(text.to_string()),
+                });
+            }
         }
     }
 
@@ -378,9 +447,27 @@ pub async fn cmd_search_global(
                         files.push(FileMetadata {
                             id: m.id as i64, folder_id, name, size,
                             mime_type: Some(mime), file_ext: ext,
-                            created_at: m.date.to_string(), icon_type: "file".into()
+                            created_at: m.date.to_string(), icon_type: "file".into(),
+                            text_content: None,
                         });
                     }
+                } else if !m.message.trim().is_empty() {
+                    let folder_id = match m.peer_id {
+                        tl::enums::Peer::Channel(c) => Some(c.channel_id),
+                        tl::enums::Peer::User(u) => Some(u.user_id),
+                        tl::enums::Peer::Chat(c) => Some(c.chat_id),
+                    };
+                    files.push(FileMetadata {
+                        id: m.id as i64,
+                        folder_id,
+                        name: text_message_name(m.id, &m.message),
+                        size: m.message.len() as u64,
+                        mime_type: Some("text/plain".into()),
+                        file_ext: Some("txt".into()),
+                        created_at: m.date.to_string(),
+                        icon_type: "file".into(),
+                        text_content: Some(m.message),
+                    });
                 }
             }
         }
@@ -404,9 +491,27 @@ pub async fn cmd_search_global(
                         files.push(FileMetadata {
                             id: m.id as i64, folder_id, name, size,
                             mime_type: Some(mime), file_ext: ext,
-                            created_at: m.date.to_string(), icon_type: "file".into()
+                            created_at: m.date.to_string(), icon_type: "file".into(),
+                            text_content: None,
                         });
                     }
+                } else if !m.message.trim().is_empty() {
+                    let folder_id = match m.peer_id {
+                        tl::enums::Peer::Channel(c) => Some(c.channel_id),
+                        tl::enums::Peer::User(u) => Some(u.user_id),
+                        tl::enums::Peer::Chat(c) => Some(c.chat_id),
+                    };
+                    files.push(FileMetadata {
+                        id: m.id as i64,
+                        folder_id,
+                        name: text_message_name(m.id, &m.message),
+                        size: m.message.len() as u64,
+                        mime_type: Some("text/plain".into()),
+                        file_ext: Some("txt".into()),
+                        created_at: m.date.to_string(),
+                        icon_type: "file".into(),
+                        text_content: Some(m.message),
+                    });
                 }
             }
         }

--- a/app/src-tauri/src/commands/preview.rs
+++ b/app/src-tauri/src/commands/preview.rs
@@ -4,7 +4,7 @@ use grammers_client::types::Media;
 use base64::{Engine as _, engine::general_purpose};
 use crate::TelegramState;
 use crate::bandwidth::BandwidthManager;
-use crate::commands::utils::resolve_peer;
+use crate::commands::utils::resolve_peer_ref;
 
 const PREVIEW_CACHE_MAX_FILES: usize = 30;
 const PREVIEW_CACHE_MAX_TOTAL_BYTES: u64 = 80 * 1024 * 1024;
@@ -63,8 +63,8 @@ pub async fn cmd_get_preview(
     }
     let client = client_opt.unwrap();
 
-    let peer = resolve_peer(&client, folder_id, &state.peer_cache).await?;
-    let messages = client.get_messages_by_id(&peer, &[message_id])
+    let peer = resolve_peer_ref(&client, folder_id, &state.peer_cache).await?;
+    let messages = client.get_messages_by_id(peer, &[message_id])
         .await.map_err(|e| e.to_string())?;
     let target_message = messages.into_iter().flatten().next();
 
@@ -228,8 +228,8 @@ pub async fn cmd_get_thumbnail(
     }
     let client = client_opt.unwrap();
 
-    let peer = resolve_peer(&client, folder_id, &state.peer_cache).await?;
-    let messages = client.get_messages_by_id(&peer, &[message_id])
+    let peer = resolve_peer_ref(&client, folder_id, &state.peer_cache).await?;
+    let messages = client.get_messages_by_id(peer, &[message_id])
         .await.map_err(|e| e.to_string())?;
     if let Some(m) = messages.into_iter().flatten().next() {
         if let Some(media) = m.media() {

--- a/app/src-tauri/src/commands/preview.rs
+++ b/app/src-tauri/src/commands/preview.rs
@@ -153,6 +153,12 @@ pub async fn cmd_get_preview(
                 log::info!("Returning path preview: {}", save_path_str);
                 return Ok(save_path_str);
             }
+        } else {
+            let text = msg.text();
+            if !text.trim().is_empty() {
+                let b64 = general_purpose::STANDARD.encode(text.as_bytes());
+                return Ok(format!("data:text/plain;base64,{}", b64));
+            }
         }
     }
     Err("File not found or failed to download".to_string())

--- a/app/src-tauri/src/commands/utils.rs
+++ b/app/src-tauri/src/commands/utils.rs
@@ -1,5 +1,7 @@
 use grammers_client::Client;
 use grammers_client::types::Peer;
+use grammers_session::types::PeerRef;
+use grammers_tl_types as tl;
 use tauri::State;
 use crate::bandwidth::BandwidthManager;
 use std::collections::HashMap;
@@ -52,6 +54,20 @@ pub async fn resolve_peer(
             Err(e) => Err(e.to_string()),
         }
     }
+}
+
+pub async fn resolve_peer_ref(
+    client: &Client,
+    folder_id: Option<i64>,
+    peer_cache: &Arc<RwLock<HashMap<i64, Peer>>>,
+) -> Result<PeerRef, String> {
+    if folder_id.is_none() {
+        return Ok(tl::enums::InputPeer::PeerSelf.into());
+    }
+
+    resolve_peer(client, folder_id, peer_cache)
+        .await
+        .map(PeerRef::from)
 }
 
 /// Clear the peer cache (called on logout)

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod models;
+pub mod nas;
 
 pub mod commands;
 pub mod bandwidth;
@@ -9,6 +10,7 @@ use std::sync::Arc;
 use std::collections::HashMap;
 use commands::TelegramState;
 use commands::streaming::StreamConfig;
+use nas::state::NasState;
 use rand::Rng;
 
 pub mod server;
@@ -50,7 +52,7 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .setup(move |app| {
-            app.manage(TelegramState {
+            let telegram_state = TelegramState {
                 client: Arc::new(Mutex::new(None)),
                 login_token: Arc::new(Mutex::new(None)),
                 password_token: Arc::new(Mutex::new(None)),
@@ -58,19 +60,51 @@ pub fn run() {
                 runner_shutdown: Arc::new(std::sync::Mutex::new(None)),
                 runner_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
                 peer_cache: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
-            });
+            };
+            let telegram_state_arc = Arc::new(telegram_state.clone());
+            app.manage(telegram_state);
             app.manage(bandwidth::BandwidthManager::new(app.handle()));
             app.manage(StreamConfig { token: stream_token.clone(), port: STREAM_PORT });
             app.manage(ActixServerHandle(server_handle_for_setup.clone()));
+
+            let app_data_dir = app
+                .path()
+                .app_data_dir()
+                .map_err(|err| err.to_string())?;
+            let api_base_url = format!("http://127.0.0.1:{}", STREAM_PORT);
+            let nas_state = tauri::async_runtime::block_on(NasState::new(
+                app_data_dir.clone(),
+                api_base_url,
+                telegram_state_arc.clone(),
+            ))?;
+            app.manage(nas_state.clone());
+
+            let nas_state_for_reconnect = nas_state.clone();
+            tauri::async_runtime::spawn(async move {
+                if let Ok(Some(encrypted_api_id)) = nas_state_for_reconnect
+                    .db
+                    .get_secret("owner_api_id".to_string())
+                    .await
+                {
+                    if let Ok(api_id_str) = nas::crypto::decrypt_secret(
+                        &encrypted_api_id,
+                        nas_state_for_reconnect.master_key.as_ref(),
+                    ) {
+                        if let Ok(api_id) = api_id_str.parse::<i32>() {
+                            *nas_state_for_reconnect.telegram.api_id.lock().await = Some(api_id);
+                        }
+                    }
+                }
+            });
             
             // Start Streaming Server on dedicated thread (Actix needs its own runtime)
-            let state = Arc::new(app.state::<TelegramState>().inner().clone());
+            let nas_state_for_server = nas_state.clone();
             let token_for_server = stream_token.clone();
             let handle_for_thread = server_handle_for_setup.clone();
             std::thread::spawn(move || {
                 let sys = actix_rt::System::new();
                 sys.block_on(async move {
-                    match server::start_server(state, STREAM_PORT, token_for_server).await {
+                    match server::start_server(nas_state_for_server, STREAM_PORT, token_for_server).await {
                         Ok(server) => {
                             // Store the handle so RunEvent::Exit can stop it
                             *handle_for_thread.lock().unwrap() = Some(server.handle());

--- a/app/src-tauri/src/models.rs
+++ b/app/src-tauri/src/models.rs
@@ -26,6 +26,7 @@ pub struct FileMetadata {
     pub file_ext: Option<String>, // Added field
     pub created_at: String, 
     pub icon_type: String, 
+    pub text_content: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/app/src-tauri/src/nas/api.rs
+++ b/app/src-tauri/src/nas/api.rs
@@ -1,0 +1,646 @@
+use actix_web::cookie::{Cookie, SameSite};
+use actix_web::{delete, get, http::header, post, put, web, HttpRequest, HttpResponse, Responder};
+use serde_json::json;
+use time::Duration;
+
+use super::crypto::{
+    decrypt_secret, encrypt_secret, generate_token, hash_password, now_ts, sha256_hex,
+    verify_password,
+};
+use super::models::{
+    AppRole, AuthClaims, BootstrapRequest, LoginRequest, LoginResponse, MeResponse,
+    OwnerConfigRequest, PermissionUpdateRequest, QrTokenResponse, SystemStatus, UserPatchRequest,
+    UserUpsertRequest,
+};
+use super::state::NasState;
+
+const SESSION_TTL_SECONDS: i64 = 60 * 60 * 24 * 14;
+const QR_TTL_SECONDS: i64 = 60 * 10;
+
+#[derive(Clone)]
+struct RequestContext {
+    user_id: String,
+    session_id: String,
+    csrf_token: String,
+}
+
+pub fn configure_api(cfg: &mut web::ServiceConfig) {
+    cfg.service(system_status)
+        .service(me)
+        .service(login)
+        .service(logout)
+        .service(redeem_qr)
+        .service(bootstrap_admin)
+        .service(list_users)
+        .service(create_user)
+        .service(update_user)
+        .service(delete_user)
+        .service(list_sessions)
+        .service(revoke_session)
+        .service(generate_qr)
+        .service(revoke_user_qr_tokens)
+        .service(get_permissions)
+        .service(set_permissions)
+        .service(store_owner_config)
+        .service(get_owner_status)
+        .service(list_audit_logs);
+}
+
+#[get("/api/system/status")]
+async fn system_status(state: web::Data<NasState>) -> impl Responder {
+    let setup_required = match state.db.setup_required().await {
+        Ok(value) => value,
+        Err(err) => return HttpResponse::InternalServerError().json(json!({ "error": err })),
+    };
+    let owner_configured = state.db.owner_configured().await.unwrap_or(false);
+    let owner_connected = state.telegram.client.lock().await.is_some();
+
+    HttpResponse::Ok().json(SystemStatus {
+        setup_required,
+        owner_configured,
+        owner_connected,
+        api_base_url: state.api_base_url.clone(),
+    })
+}
+
+#[post("/api/admin/bootstrap")]
+async fn bootstrap_admin(
+    state: web::Data<NasState>,
+    payload: web::Json<BootstrapRequest>,
+    req: HttpRequest,
+) -> impl Responder {
+    if !state
+        .allow_rate(format!("bootstrap:{}", client_ip(&req)), 5, 60)
+        .await
+    {
+        return HttpResponse::TooManyRequests().json(json!({ "error": "Too many setup attempts" }));
+    }
+
+    match state.db.setup_required().await {
+        Ok(false) => {
+            return HttpResponse::Conflict().json(json!({ "error": "System is already initialized" }))
+        }
+        Err(err) => return HttpResponse::InternalServerError().json(json!({ "error": err })),
+        _ => {}
+    }
+
+    let password_hash = match hash_password(&payload.password) {
+        Ok(hash) => hash,
+        Err(err) => return HttpResponse::InternalServerError().json(json!({ "error": err })),
+    };
+
+    let admin = match state
+        .db
+        .create_user(
+            payload.username.clone(),
+            payload.display_name.clone(),
+            password_hash,
+            AppRole::Admin,
+            false,
+        )
+        .await
+    {
+        Ok(user) => user,
+        Err(err) => return HttpResponse::BadRequest().json(json!({ "error": err })),
+    };
+
+    let _ = state
+        .db
+        .add_audit_log(
+            Some(admin.id.clone()),
+            "bootstrap_admin".to_string(),
+            "user".to_string(),
+            admin.id.clone(),
+            "{}".to_string(),
+        )
+        .await;
+
+    issue_login_response(&state, &admin, &req).await
+}
+
+#[post("/api/auth/login")]
+async fn login(
+    state: web::Data<NasState>,
+    payload: web::Json<LoginRequest>,
+    req: HttpRequest,
+) -> impl Responder {
+    if !state
+        .allow_rate(format!("login:{}", client_ip(&req)), 10, 60)
+        .await
+    {
+        return HttpResponse::TooManyRequests().json(json!({ "error": "Too many login attempts" }));
+    }
+
+    let record = match state.db.get_user_by_username(payload.username.clone()).await {
+        Ok(Some(record)) => record,
+        Ok(None) => {
+            return HttpResponse::Unauthorized().json(json!({ "error": "Invalid credentials" }))
+        }
+        Err(err) => return HttpResponse::InternalServerError().json(json!({ "error": err })),
+    };
+
+    let (user, password_hash) = record;
+    if user.disabled {
+        return HttpResponse::Forbidden().json(json!({ "error": "User is disabled" }));
+    }
+
+    match verify_password(&payload.password, &password_hash) {
+        Ok(true) => issue_login_response(&state, &user, &req).await,
+        Ok(false) => HttpResponse::Unauthorized().json(json!({ "error": "Invalid credentials" })),
+        Err(err) => HttpResponse::InternalServerError().json(json!({ "error": err })),
+    }
+}
+
+#[post("/api/auth/logout")]
+async fn logout(state: web::Data<NasState>, req: HttpRequest) -> impl Responder {
+    if let Ok(ctx) = authorize(&state, &req, false).await {
+        let _ = state.db.revoke_session(ctx.session_id).await;
+    }
+
+    HttpResponse::Ok()
+        .cookie(
+            Cookie::build(state.session_cookie_name.clone(), "")
+                .path("/")
+                .max_age(Duration::seconds(0))
+                .http_only(true)
+                .same_site(SameSite::Lax)
+                .finish(),
+        )
+        .json(json!({ "ok": true }))
+}
+
+#[get("/api/auth/me")]
+async fn me(state: web::Data<NasState>, req: HttpRequest) -> impl Responder {
+    let ctx = match authorize(&state, &req, false).await {
+        Ok(ctx) => ctx,
+        Err(resp) => return resp,
+    };
+    let user = match state.db.get_user_by_id(ctx.user_id.clone()).await {
+        Ok(Some(user)) => user,
+        Ok(None) => return HttpResponse::Unauthorized().json(json!({ "error": "Unknown user" })),
+        Err(err) => return HttpResponse::InternalServerError().json(json!({ "error": err })),
+    };
+    let permissions = match state.db.get_permissions(user.id.clone()).await {
+        Ok(permissions) => permissions,
+        Err(err) => return HttpResponse::InternalServerError().json(json!({ "error": err })),
+    };
+
+    HttpResponse::Ok().json(MeResponse {
+        user,
+        permissions,
+        owner_connected: state.telegram.client.lock().await.is_some(),
+        csrf_token: ctx.csrf_token,
+    })
+}
+
+#[post("/api/auth/qr/redeem/{token}")]
+async fn redeem_qr(
+    state: web::Data<NasState>,
+    path: web::Path<String>,
+    req: HttpRequest,
+) -> impl Responder {
+    if !state
+        .allow_rate(format!("qr:{}", client_ip(&req)), 15, 60)
+        .await
+    {
+        return HttpResponse::TooManyRequests().json(json!({ "error": "Too many QR attempts" }));
+    }
+
+    let token_hash = sha256_hex(&path.into_inner());
+    let redemption = match state.db.redeem_qr_token(token_hash).await {
+        Ok(Some(redemption)) => redemption,
+        Ok(None) => return HttpResponse::Unauthorized().json(json!({ "error": "Invalid or expired QR token" })),
+        Err(err) => return HttpResponse::InternalServerError().json(json!({ "error": err })),
+    };
+
+    if redemption.user.disabled {
+        return HttpResponse::Forbidden().json(json!({ "error": "User is disabled" }));
+    }
+
+    issue_login_response(&state, &redemption.user, &req).await
+}
+
+#[get("/api/admin/users")]
+async fn list_users(state: web::Data<NasState>, req: HttpRequest) -> impl Responder {
+    if let Err(resp) = authorize(&state, &req, true).await {
+        return resp;
+    }
+    match state.db.list_users().await {
+        Ok(users) => HttpResponse::Ok().json(users),
+        Err(err) => HttpResponse::InternalServerError().json(json!({ "error": err })),
+    }
+}
+
+#[post("/api/admin/users")]
+async fn create_user(
+    state: web::Data<NasState>,
+    req: HttpRequest,
+    payload: web::Json<UserUpsertRequest>,
+) -> impl Responder {
+    let ctx = match authorize(&state, &req, true).await {
+        Ok(ctx) => ctx,
+        Err(resp) => return resp,
+    };
+
+    let password = match &payload.password {
+        Some(password) => password,
+        None => return HttpResponse::BadRequest().json(json!({ "error": "Password is required" })),
+    };
+    let password_hash = match hash_password(password) {
+        Ok(hash) => hash,
+        Err(err) => return HttpResponse::InternalServerError().json(json!({ "error": err })),
+    };
+
+    match state
+        .db
+        .create_user(
+            payload.username.clone(),
+            payload.display_name.clone(),
+            password_hash,
+            payload.role.clone(),
+            payload.disabled,
+        )
+        .await
+    {
+        Ok(user) => {
+            let _ = state
+                .db
+                .add_audit_log(
+                    Some(ctx.user_id),
+                    "create_user".to_string(),
+                    "user".to_string(),
+                    user.id.clone(),
+                    "{}".to_string(),
+                )
+                .await;
+            HttpResponse::Ok().json(user)
+        }
+        Err(err) => HttpResponse::BadRequest().json(json!({ "error": err })),
+    }
+}
+
+#[put("/api/admin/users/{user_id}")]
+async fn update_user(
+    state: web::Data<NasState>,
+    req: HttpRequest,
+    path: web::Path<String>,
+    payload: web::Json<UserPatchRequest>,
+) -> impl Responder {
+    let ctx = match authorize(&state, &req, true).await {
+        Ok(ctx) => ctx,
+        Err(resp) => return resp,
+    };
+    let password_hash = match payload.password.as_ref() {
+        Some(password) => match hash_password(password) {
+            Ok(hash) => Some(hash),
+            Err(err) => return HttpResponse::InternalServerError().json(json!({ "error": err })),
+        },
+        None => None,
+    };
+    let user_id = path.into_inner();
+
+    match state
+        .db
+        .patch_user(
+            user_id.clone(),
+            payload.display_name.clone(),
+            payload.disabled,
+            payload.role.clone(),
+            password_hash,
+        )
+        .await
+    {
+        Ok(()) => {
+            let _ = state
+                .db
+                .add_audit_log(
+                    Some(ctx.user_id),
+                    "update_user".to_string(),
+                    "user".to_string(),
+                    user_id,
+                    "{}".to_string(),
+                )
+                .await;
+            HttpResponse::Ok().json(json!({ "ok": true }))
+        }
+        Err(err) => HttpResponse::BadRequest().json(json!({ "error": err })),
+    }
+}
+
+#[delete("/api/admin/users/{user_id}")]
+async fn delete_user(
+    state: web::Data<NasState>,
+    req: HttpRequest,
+    path: web::Path<String>,
+) -> impl Responder {
+    let ctx = match authorize(&state, &req, true).await {
+        Ok(ctx) => ctx,
+        Err(resp) => return resp,
+    };
+    let user_id = path.into_inner();
+    if user_id == ctx.user_id {
+        return HttpResponse::BadRequest().json(json!({ "error": "Admin cannot delete the current session owner" }));
+    }
+    match state.db.delete_user(user_id.clone()).await {
+        Ok(()) => {
+            let _ = state
+                .db
+                .add_audit_log(
+                    Some(ctx.user_id),
+                    "delete_user".to_string(),
+                    "user".to_string(),
+                    user_id,
+                    "{}".to_string(),
+                )
+                .await;
+            HttpResponse::Ok().json(json!({ "ok": true }))
+        }
+        Err(err) => HttpResponse::BadRequest().json(json!({ "error": err })),
+    }
+}
+
+#[get("/api/admin/sessions")]
+async fn list_sessions(state: web::Data<NasState>, req: HttpRequest) -> impl Responder {
+    if let Err(resp) = authorize(&state, &req, true).await {
+        return resp;
+    }
+    match state.db.list_sessions().await {
+        Ok(sessions) => HttpResponse::Ok().json(sessions),
+        Err(err) => HttpResponse::InternalServerError().json(json!({ "error": err })),
+    }
+}
+
+#[delete("/api/admin/sessions/{session_id}")]
+async fn revoke_session(
+    state: web::Data<NasState>,
+    req: HttpRequest,
+    path: web::Path<String>,
+) -> impl Responder {
+    if let Err(resp) = authorize(&state, &req, true).await {
+        return resp;
+    }
+    match state.db.revoke_session(path.into_inner()).await {
+        Ok(()) => HttpResponse::Ok().json(json!({ "ok": true })),
+        Err(err) => HttpResponse::InternalServerError().json(json!({ "error": err })),
+    }
+}
+
+#[post("/api/admin/users/{user_id}/qr")]
+async fn generate_qr(
+    state: web::Data<NasState>,
+    req: HttpRequest,
+    path: web::Path<String>,
+) -> impl Responder {
+    let ctx = match authorize(&state, &req, true).await {
+        Ok(ctx) => ctx,
+        Err(resp) => return resp,
+    };
+    let user_id = path.into_inner();
+    let raw_token = generate_token();
+    let expires_at = now_ts() + QR_TTL_SECONDS;
+    let login_url = format!("{}/?qr={}", state.api_base_url, raw_token);
+
+    match state
+        .db
+        .create_qr_token(
+            user_id.clone(),
+            sha256_hex(&raw_token),
+            ctx.user_id,
+            expires_at,
+        )
+        .await
+    {
+        Ok(()) => HttpResponse::Ok().json(QrTokenResponse {
+            token: raw_token,
+            login_url,
+            expires_at,
+            user_id,
+        }),
+        Err(err) => HttpResponse::InternalServerError().json(json!({ "error": err })),
+    }
+}
+
+#[delete("/api/admin/users/{user_id}/qr")]
+async fn revoke_user_qr_tokens(
+    state: web::Data<NasState>,
+    req: HttpRequest,
+    path: web::Path<String>,
+) -> impl Responder {
+    if let Err(resp) = authorize(&state, &req, true).await {
+        return resp;
+    }
+    match state.db.revoke_qr_tokens_for_user(path.into_inner()).await {
+        Ok(()) => HttpResponse::Ok().json(json!({ "ok": true })),
+        Err(err) => HttpResponse::InternalServerError().json(json!({ "error": err })),
+    }
+}
+
+#[get("/api/admin/users/{user_id}/permissions")]
+async fn get_permissions(
+    state: web::Data<NasState>,
+    req: HttpRequest,
+    path: web::Path<String>,
+) -> impl Responder {
+    if let Err(resp) = authorize(&state, &req, true).await {
+        return resp;
+    }
+    match state.db.get_permissions(path.into_inner()).await {
+        Ok(permissions) => HttpResponse::Ok().json(permissions),
+        Err(err) => HttpResponse::InternalServerError().json(json!({ "error": err })),
+    }
+}
+
+#[put("/api/admin/users/{user_id}/permissions")]
+async fn set_permissions(
+    state: web::Data<NasState>,
+    req: HttpRequest,
+    path: web::Path<String>,
+    payload: web::Json<PermissionUpdateRequest>,
+) -> impl Responder {
+    if let Err(resp) = authorize(&state, &req, true).await {
+        return resp;
+    }
+    match state
+        .db
+        .set_permissions(path.into_inner(), payload.permissions.clone())
+        .await
+    {
+        Ok(()) => HttpResponse::Ok().json(json!({ "ok": true })),
+        Err(err) => HttpResponse::InternalServerError().json(json!({ "error": err })),
+    }
+}
+
+#[post("/api/admin/owner/config")]
+async fn store_owner_config(
+    state: web::Data<NasState>,
+    req: HttpRequest,
+    payload: web::Json<OwnerConfigRequest>,
+) -> impl Responder {
+    if let Err(resp) = authorize(&state, &req, true).await {
+        return resp;
+    }
+
+    let encrypted_api_id = match encrypt_secret(&payload.api_id.to_string(), state.master_key.as_ref()) {
+        Ok(value) => value,
+        Err(err) => return HttpResponse::InternalServerError().json(json!({ "error": err })),
+    };
+    let encrypted_api_hash = match encrypt_secret(&payload.api_hash, state.master_key.as_ref()) {
+        Ok(value) => value,
+        Err(err) => return HttpResponse::InternalServerError().json(json!({ "error": err })),
+    };
+
+    if let Err(err) = state.db.store_secret("owner_api_id".to_string(), encrypted_api_id).await {
+        return HttpResponse::InternalServerError().json(json!({ "error": err }));
+    }
+    if let Err(err) = state
+        .db
+        .store_secret("owner_api_hash".to_string(), encrypted_api_hash)
+        .await
+    {
+        return HttpResponse::InternalServerError().json(json!({ "error": err }));
+    }
+
+    HttpResponse::Ok().json(json!({ "ok": true }))
+}
+
+#[get("/api/admin/owner/status")]
+async fn get_owner_status(state: web::Data<NasState>, req: HttpRequest) -> impl Responder {
+    if let Err(resp) = authorize(&state, &req, true).await {
+        return resp;
+    }
+
+    let owner_api_id = match state.db.get_secret("owner_api_id".to_string()).await {
+        Ok(value) => value,
+        Err(err) => return HttpResponse::InternalServerError().json(json!({ "error": err })),
+    };
+    let decrypted_api_id = owner_api_id
+        .as_ref()
+        .and_then(|value| decrypt_secret(value, state.master_key.as_ref()).ok());
+
+    HttpResponse::Ok().json(json!({
+        "configured": owner_api_id.is_some(),
+        "api_id": decrypted_api_id,
+        "connected": state.telegram.client.lock().await.is_some()
+    }))
+}
+
+#[get("/api/admin/audit-logs")]
+async fn list_audit_logs(state: web::Data<NasState>, req: HttpRequest) -> impl Responder {
+    if let Err(resp) = authorize(&state, &req, true).await {
+        return resp;
+    }
+    match state.db.list_audit_logs().await {
+        Ok(entries) => HttpResponse::Ok().json(entries),
+        Err(err) => HttpResponse::InternalServerError().json(json!({ "error": err })),
+    }
+}
+
+async fn issue_login_response(
+    state: &NasState,
+    user: &super::models::AppUser,
+    req: &HttpRequest,
+) -> HttpResponse {
+    let csrf_token = generate_token();
+    let session = match state
+        .db
+        .create_session(
+            user,
+            csrf_token.clone(),
+            client_ip(req),
+            user_agent(req),
+            SESSION_TTL_SECONDS,
+        )
+        .await
+    {
+        Ok(session) => session,
+        Err(err) => return HttpResponse::InternalServerError().json(json!({ "error": err })),
+    };
+
+    let claims = AuthClaims {
+        sub: user.id.clone(),
+        sid: session.id.clone(),
+        role: user.role.as_str().to_string(),
+        exp: session.expires_at as usize,
+    };
+    let jwt = match state.issue_session_jwt(&claims) {
+        Ok(jwt) => jwt,
+        Err(err) => return HttpResponse::InternalServerError().json(json!({ "error": err })),
+    };
+
+    HttpResponse::Ok()
+        .cookie(
+            Cookie::build(state.session_cookie_name.clone(), jwt.clone())
+                .path("/")
+                .http_only(true)
+                .same_site(SameSite::Lax)
+                .max_age(Duration::seconds(SESSION_TTL_SECONDS))
+                .finish(),
+        )
+        .json(LoginResponse {
+            user: user.clone(),
+            csrf_token,
+            access_token: jwt,
+        })
+}
+
+async fn authorize(
+    state: &NasState,
+    req: &HttpRequest,
+    admin_only: bool,
+) -> Result<RequestContext, HttpResponse> {
+    let token = req
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .map(str::to_owned)
+        .or_else(|| req.cookie(&state.session_cookie_name).map(|cookie| cookie.value().to_string()))
+        .ok_or_else(|| HttpResponse::Unauthorized().json(json!({ "error": "Missing session token" })))?;
+    let claims = state
+        .decode_session_jwt(&token)
+        .map_err(|_| HttpResponse::Unauthorized().json(json!({ "error": "Invalid session" })))?;
+    let record = state
+        .db
+        .get_session(claims.sid.clone())
+        .await
+        .map_err(|err| HttpResponse::InternalServerError().json(json!({ "error": err })))?;
+    let record = record
+        .ok_or_else(|| HttpResponse::Unauthorized().json(json!({ "error": "Session expired" })))?;
+    if record.disabled || record.session.expires_at < now_ts() {
+        return Err(HttpResponse::Unauthorized().json(json!({ "error": "Session is no longer valid" })));
+    }
+    if admin_only && record.role != AppRole::Admin {
+        return Err(HttpResponse::Forbidden().json(json!({ "error": "Admin access required" })));
+    }
+    if req.method() != actix_web::http::Method::GET {
+        let csrf = req
+            .headers()
+            .get("x-csrf-token")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default();
+        if csrf != record.csrf_token {
+            return Err(HttpResponse::Forbidden().json(json!({ "error": "Invalid CSRF token" })));
+        }
+    }
+    let _ = state.db.touch_session(record.session.id.clone()).await;
+    Ok(RequestContext {
+        user_id: record.session.user_id,
+        session_id: record.session.id,
+        csrf_token: record.csrf_token,
+    })
+}
+
+fn client_ip(req: &HttpRequest) -> String {
+    req.connection_info()
+        .realip_remote_addr()
+        .unwrap_or("local")
+        .to_string()
+}
+
+fn user_agent(req: &HttpRequest) -> String {
+    req.headers()
+        .get(header::USER_AGENT)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("unknown")
+        .to_string()
+}

--- a/app/src-tauri/src/nas/crypto.rs
+++ b/app/src-tauri/src/nas/crypto.rs
@@ -1,0 +1,120 @@
+use aes_gcm_siv::aead::{Aead, KeyInit};
+use aes_gcm_siv::{Aes256GcmSiv, Nonce};
+use argon2::{
+    password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+    Argon2,
+};
+use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine as _};
+use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use time::OffsetDateTime;
+
+use super::models::AuthClaims;
+
+pub fn hash_password(password: &str) -> Result<String, String> {
+    let salt = SaltString::generate(&mut argon2::password_hash::rand_core::OsRng);
+    Argon2::default()
+        .hash_password(password.as_bytes(), &salt)
+        .map(|hash| hash.to_string())
+        .map_err(|err| err.to_string())
+}
+
+pub fn verify_password(password: &str, hash: &str) -> Result<bool, String> {
+    let parsed = PasswordHash::new(hash).map_err(|err| err.to_string())?;
+    Ok(Argon2::default()
+        .verify_password(password.as_bytes(), &parsed)
+        .is_ok())
+}
+
+pub fn generate_token() -> String {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    STANDARD_NO_PAD.encode(bytes)
+}
+
+pub fn sha256_hex(input: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(input.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+pub fn ensure_master_key(path: &Path) -> Result<Vec<u8>, String> {
+    if let Ok(existing) = fs::read(path) {
+        return Ok(existing);
+    }
+
+    let mut bytes = vec![0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    fs::write(path, &bytes).map_err(|err| err.to_string())?;
+
+    #[cfg(target_family = "unix")]
+    {
+        let perms = fs::Permissions::from_mode(0o600);
+        let _ = fs::set_permissions(path, perms);
+    }
+
+    Ok(bytes)
+}
+
+pub fn encrypt_secret(secret: &str, key: &[u8]) -> Result<String, String> {
+    let cipher = Aes256GcmSiv::new_from_slice(key).map_err(|err| err.to_string())?;
+    let mut nonce_bytes = [0u8; 12];
+    rand::thread_rng().fill_bytes(&mut nonce_bytes);
+    let ciphertext = cipher
+        .encrypt(Nonce::from_slice(&nonce_bytes), secret.as_bytes())
+        .map_err(|err| err.to_string())?;
+
+    Ok(format!(
+        "{}:{}",
+        STANDARD_NO_PAD.encode(nonce_bytes),
+        STANDARD_NO_PAD.encode(ciphertext)
+    ))
+}
+
+pub fn decrypt_secret(encrypted: &str, key: &[u8]) -> Result<String, String> {
+    let (nonce_b64, data_b64) = encrypted
+        .split_once(':')
+        .ok_or("Invalid encrypted secret format")?;
+    let nonce = STANDARD_NO_PAD
+        .decode(nonce_b64)
+        .map_err(|err| err.to_string())?;
+    let data = STANDARD_NO_PAD
+        .decode(data_b64)
+        .map_err(|err| err.to_string())?;
+
+    let cipher = Aes256GcmSiv::new_from_slice(key).map_err(|err| err.to_string())?;
+    let plaintext = cipher
+        .decrypt(Nonce::from_slice(&nonce), data.as_ref())
+        .map_err(|err| err.to_string())?;
+    String::from_utf8(plaintext).map_err(|err| err.to_string())
+}
+
+pub fn issue_jwt(
+    claims: &AuthClaims,
+    signing_key: &[u8],
+) -> Result<String, String> {
+    encode(
+        &Header::default(),
+        claims,
+        &EncodingKey::from_secret(signing_key),
+    )
+    .map_err(|err| err.to_string())
+}
+
+pub fn decode_jwt(token: &str, signing_key: &[u8]) -> Result<AuthClaims, String> {
+    decode::<AuthClaims>(
+        token,
+        &DecodingKey::from_secret(signing_key),
+        &Validation::default(),
+    )
+    .map(|data| data.claims)
+    .map_err(|err| err.to_string())
+}
+
+pub fn now_ts() -> i64 {
+    OffsetDateTime::now_utc().unix_timestamp()
+}

--- a/app/src-tauri/src/nas/db.rs
+++ b/app/src-tauri/src/nas/db.rs
@@ -1,0 +1,727 @@
+use sqlite::{Connection, State};
+use std::path::PathBuf;
+use tokio::task;
+use uuid::Uuid;
+
+use super::models::{
+    AccessLevel, AppRole, AppSession, AppUser, AuditEntry, PermissionAssignment,
+};
+
+#[derive(Clone)]
+pub struct Database {
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionRecord {
+    pub session: AppSession,
+    pub csrf_token: String,
+    pub role: AppRole,
+    pub disabled: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct QrRedemption {
+    pub user: AppUser,
+    pub permissions: Vec<PermissionAssignment>,
+}
+
+impl Database {
+    pub async fn new(path: PathBuf) -> Result<Self, String> {
+        let db = Self { path };
+        db.init().await?;
+        Ok(db)
+    }
+
+    async fn with_conn<T, F>(&self, func: F) -> Result<T, String>
+    where
+        T: Send + 'static,
+        F: FnOnce(Connection) -> Result<T, String> + Send + 'static,
+    {
+        let path = self.path.clone();
+        task::spawn_blocking(move || {
+            let conn = sqlite::open(path).map_err(|err| err.to_string())?;
+            conn.execute("PRAGMA foreign_keys = ON")
+                .map_err(|err| err.to_string())?;
+            func(conn)
+        })
+        .await
+        .map_err(|err| err.to_string())?
+    }
+
+    pub async fn init(&self) -> Result<(), String> {
+        self.with_conn(|conn| {
+            conn.execute(
+                r#"
+                CREATE TABLE IF NOT EXISTS roles (
+                  id TEXT PRIMARY KEY,
+                  name TEXT NOT NULL UNIQUE,
+                  description TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS users (
+                  id TEXT PRIMARY KEY,
+                  username TEXT NOT NULL UNIQUE,
+                  display_name TEXT NOT NULL,
+                  password_hash TEXT NOT NULL,
+                  role_id TEXT NOT NULL REFERENCES roles(id),
+                  disabled INTEGER NOT NULL DEFAULT 0,
+                  created_at INTEGER NOT NULL,
+                  updated_at INTEGER NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS sessions (
+                  id TEXT PRIMARY KEY,
+                  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                  csrf_token TEXT NOT NULL,
+                  user_agent TEXT NOT NULL,
+                  ip_address TEXT NOT NULL,
+                  created_at INTEGER NOT NULL,
+                  expires_at INTEGER NOT NULL,
+                  last_seen_at INTEGER NOT NULL,
+                  revoked_at INTEGER
+                );
+                CREATE TABLE IF NOT EXISTS qr_tokens (
+                  id TEXT PRIMARY KEY,
+                  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                  token_hash TEXT NOT NULL UNIQUE,
+                  expires_at INTEGER NOT NULL,
+                  max_uses INTEGER NOT NULL DEFAULT 1,
+                  current_uses INTEGER NOT NULL DEFAULT 0,
+                  revoked_at INTEGER,
+                  created_at INTEGER NOT NULL,
+                  created_by TEXT REFERENCES users(id),
+                  last_used_at INTEGER
+                );
+                CREATE TABLE IF NOT EXISTS permissions (
+                  id TEXT PRIMARY KEY,
+                  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                  folder_id TEXT NOT NULL,
+                  folder_label TEXT NOT NULL,
+                  access_level TEXT NOT NULL,
+                  is_private INTEGER NOT NULL DEFAULT 0,
+                  created_at INTEGER NOT NULL,
+                  updated_at INTEGER NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS shared_folders (
+                  id TEXT PRIMARY KEY,
+                  folder_id TEXT NOT NULL UNIQUE,
+                  owner_user_id TEXT REFERENCES users(id),
+                  display_name TEXT NOT NULL,
+                  created_at INTEGER NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS audit_logs (
+                  id TEXT PRIMARY KEY,
+                  actor_user_id TEXT REFERENCES users(id),
+                  action TEXT NOT NULL,
+                  target_type TEXT NOT NULL,
+                  target_id TEXT NOT NULL,
+                  metadata_json TEXT NOT NULL,
+                  created_at INTEGER NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS secrets (
+                  key TEXT PRIMARY KEY,
+                  value TEXT NOT NULL,
+                  updated_at INTEGER NOT NULL
+                );
+                "#,
+            )
+            .map_err(|err| err.to_string())?;
+
+            execute_bind3(
+                &conn,
+                "INSERT OR IGNORE INTO roles (id, name, description) VALUES (?1, ?2, ?3)",
+                "admin",
+                "admin",
+                "Full administrative access",
+            )?;
+            execute_bind3(
+                &conn,
+                "INSERT OR IGNORE INTO roles (id, name, description) VALUES (?1, ?2, ?3)",
+                "user",
+                "user",
+                "Standard NAS user",
+            )?;
+            Ok(())
+        })
+        .await
+    }
+
+    pub async fn setup_required(&self) -> Result<bool, String> {
+        self.with_conn(|conn| {
+            let mut statement = conn
+                .prepare("SELECT COUNT(*) FROM users")
+                .map_err(|err| err.to_string())?;
+            match statement.next().map_err(|err| err.to_string())? {
+                State::Row => Ok(statement.read::<i64, _>(0).map_err(|err| err.to_string())? == 0),
+                State::Done => Ok(true),
+            }
+        })
+        .await
+    }
+
+    pub async fn owner_configured(&self) -> Result<bool, String> {
+        Ok(self.get_secret("owner_api_id".to_string()).await?.is_some())
+    }
+
+    pub async fn create_user(
+        &self,
+        username: String,
+        display_name: String,
+        password_hash: String,
+        role: AppRole,
+        disabled: bool,
+    ) -> Result<AppUser, String> {
+        self.with_conn(move |conn| {
+            let now = crate::nas::crypto::now_ts();
+            let user = AppUser {
+                id: Uuid::new_v4().to_string(),
+                username,
+                display_name,
+                role: role.clone(),
+                disabled,
+                created_at: now,
+            };
+            let mut statement = conn
+                .prepare(
+                    "INSERT INTO users (id, username, display_name, password_hash, role_id, disabled, created_at, updated_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                )
+                .map_err(|err| err.to_string())?;
+            statement.bind((1, user.id.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((2, user.username.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((3, user.display_name.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((4, password_hash.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((5, role.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((6, if user.disabled { 1 } else { 0 })).map_err(|err| err.to_string())?;
+            statement.bind((7, user.created_at)).map_err(|err| err.to_string())?;
+            statement.bind((8, now)).map_err(|err| err.to_string())?;
+            statement.next().map_err(|err| err.to_string())?;
+            Ok(user)
+        })
+        .await
+    }
+
+    pub async fn list_users(&self) -> Result<Vec<AppUser>, String> {
+        self.with_conn(|conn| {
+            let mut statement = conn
+                .prepare(
+                    "SELECT id, username, display_name, role_id, disabled, created_at
+                     FROM users ORDER BY created_at ASC",
+                )
+                .map_err(|err| err.to_string())?;
+            let mut users = Vec::new();
+            while let State::Row = statement.next().map_err(|err| err.to_string())? {
+                users.push(AppUser {
+                    id: statement.read::<String, _>(0).map_err(|err| err.to_string())?,
+                    username: statement.read::<String, _>(1).map_err(|err| err.to_string())?,
+                    display_name: statement.read::<String, _>(2).map_err(|err| err.to_string())?,
+                    role: AppRole::from(statement.read::<String, _>(3).map_err(|err| err.to_string())?),
+                    disabled: statement.read::<i64, _>(4).map_err(|err| err.to_string())? != 0,
+                    created_at: statement.read::<i64, _>(5).map_err(|err| err.to_string())?,
+                });
+            }
+            Ok(users)
+        })
+        .await
+    }
+
+    pub async fn get_user_by_username(
+        &self,
+        username: String,
+    ) -> Result<Option<(AppUser, String)>, String> {
+        self.with_conn(move |conn| {
+            let mut statement = conn
+                .prepare(
+                    "SELECT id, username, display_name, role_id, disabled, created_at, password_hash
+                     FROM users WHERE username = ?1",
+                )
+                .map_err(|err| err.to_string())?;
+            statement.bind((1, username.as_str())).map_err(|err| err.to_string())?;
+            match statement.next().map_err(|err| err.to_string())? {
+                State::Row => Ok(Some((
+                    AppUser {
+                        id: statement.read::<String, _>(0).map_err(|err| err.to_string())?,
+                        username: statement.read::<String, _>(1).map_err(|err| err.to_string())?,
+                        display_name: statement.read::<String, _>(2).map_err(|err| err.to_string())?,
+                        role: AppRole::from(statement.read::<String, _>(3).map_err(|err| err.to_string())?),
+                        disabled: statement.read::<i64, _>(4).map_err(|err| err.to_string())? != 0,
+                        created_at: statement.read::<i64, _>(5).map_err(|err| err.to_string())?,
+                    },
+                    statement.read::<String, _>(6).map_err(|err| err.to_string())?,
+                ))),
+                State::Done => Ok(None),
+            }
+        })
+        .await
+    }
+
+    pub async fn get_user_by_id(&self, user_id: String) -> Result<Option<AppUser>, String> {
+        self.with_conn(move |conn| {
+            let mut statement = conn
+                .prepare(
+                    "SELECT id, username, display_name, role_id, disabled, created_at
+                     FROM users WHERE id = ?1",
+                )
+                .map_err(|err| err.to_string())?;
+            statement.bind((1, user_id.as_str())).map_err(|err| err.to_string())?;
+            match statement.next().map_err(|err| err.to_string())? {
+                State::Row => Ok(Some(AppUser {
+                    id: statement.read::<String, _>(0).map_err(|err| err.to_string())?,
+                    username: statement.read::<String, _>(1).map_err(|err| err.to_string())?,
+                    display_name: statement.read::<String, _>(2).map_err(|err| err.to_string())?,
+                    role: AppRole::from(statement.read::<String, _>(3).map_err(|err| err.to_string())?),
+                    disabled: statement.read::<i64, _>(4).map_err(|err| err.to_string())? != 0,
+                    created_at: statement.read::<i64, _>(5).map_err(|err| err.to_string())?,
+                })),
+                State::Done => Ok(None),
+            }
+        })
+        .await
+    }
+
+    pub async fn patch_user(
+        &self,
+        user_id: String,
+        display_name: Option<String>,
+        disabled: Option<bool>,
+        role: Option<AppRole>,
+        password_hash: Option<String>,
+    ) -> Result<(), String> {
+        self.with_conn(move |conn| {
+            let mut lookup = conn
+                .prepare("SELECT display_name, disabled, role_id FROM users WHERE id = ?1")
+                .map_err(|err| err.to_string())?;
+            lookup.bind((1, user_id.as_str())).map_err(|err| err.to_string())?;
+            let (current_name, current_disabled, current_role) = match lookup.next().map_err(|err| err.to_string())? {
+                State::Row => (
+                    lookup.read::<String, _>(0).map_err(|err| err.to_string())?,
+                    lookup.read::<i64, _>(1).map_err(|err| err.to_string())? != 0,
+                    lookup.read::<String, _>(2).map_err(|err| err.to_string())?,
+                ),
+                State::Done => return Err("User not found".to_string()),
+            };
+
+            let mut update = conn
+                .prepare("UPDATE users SET display_name = ?2, disabled = ?3, role_id = ?4, updated_at = ?5 WHERE id = ?1")
+                .map_err(|err| err.to_string())?;
+            update.bind((1, user_id.as_str())).map_err(|err| err.to_string())?;
+            update.bind((2, display_name.unwrap_or(current_name).as_str())).map_err(|err| err.to_string())?;
+            update.bind((3, if disabled.unwrap_or(current_disabled) { 1 } else { 0 })).map_err(|err| err.to_string())?;
+            update.bind((4, role.unwrap_or(AppRole::from(current_role)).as_str())).map_err(|err| err.to_string())?;
+            update.bind((5, crate::nas::crypto::now_ts())).map_err(|err| err.to_string())?;
+            update.next().map_err(|err| err.to_string())?;
+
+            if let Some(password_hash) = password_hash {
+                let mut pw = conn
+                    .prepare("UPDATE users SET password_hash = ?2, updated_at = ?3 WHERE id = ?1")
+                    .map_err(|err| err.to_string())?;
+                pw.bind((1, user_id.as_str())).map_err(|err| err.to_string())?;
+                pw.bind((2, password_hash.as_str())).map_err(|err| err.to_string())?;
+                pw.bind((3, crate::nas::crypto::now_ts())).map_err(|err| err.to_string())?;
+                pw.next().map_err(|err| err.to_string())?;
+            }
+
+            Ok(())
+        })
+        .await
+    }
+
+    pub async fn delete_user(&self, user_id: String) -> Result<(), String> {
+        self.with_conn(move |conn| {
+            let mut statement = conn
+                .prepare("DELETE FROM users WHERE id = ?1")
+                .map_err(|err| err.to_string())?;
+            statement.bind((1, user_id.as_str())).map_err(|err| err.to_string())?;
+            statement.next().map_err(|err| err.to_string())?;
+            Ok(())
+        })
+        .await
+    }
+
+    pub async fn create_session(
+        &self,
+        user: &AppUser,
+        csrf_token: String,
+        ip_address: String,
+        user_agent: String,
+        ttl_seconds: i64,
+    ) -> Result<AppSession, String> {
+        let user = user.clone();
+        self.with_conn(move |conn| {
+            let now = crate::nas::crypto::now_ts();
+            let session = AppSession {
+                id: Uuid::new_v4().to_string(),
+                user_id: user.id.clone(),
+                username: user.username.clone(),
+                created_at: now,
+                expires_at: now + ttl_seconds,
+                last_seen_at: now,
+                user_agent,
+                ip_address,
+            };
+            let mut statement = conn
+                .prepare(
+                    "INSERT INTO sessions (id, user_id, csrf_token, user_agent, ip_address, created_at, expires_at, last_seen_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                )
+                .map_err(|err| err.to_string())?;
+            statement.bind((1, session.id.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((2, session.user_id.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((3, csrf_token.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((4, session.user_agent.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((5, session.ip_address.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((6, session.created_at)).map_err(|err| err.to_string())?;
+            statement.bind((7, session.expires_at)).map_err(|err| err.to_string())?;
+            statement.bind((8, session.last_seen_at)).map_err(|err| err.to_string())?;
+            statement.next().map_err(|err| err.to_string())?;
+            Ok(session)
+        })
+        .await
+    }
+
+    pub async fn get_session(&self, session_id: String) -> Result<Option<SessionRecord>, String> {
+        self.with_conn(move |conn| {
+            let mut statement = conn
+                .prepare(
+                    "SELECT s.id, s.user_id, s.csrf_token, s.user_agent, s.ip_address, s.created_at, s.expires_at, s.last_seen_at,
+                            u.username, u.role_id, u.disabled
+                     FROM sessions s
+                     JOIN users u ON u.id = s.user_id
+                     WHERE s.id = ?1 AND s.revoked_at IS NULL",
+                )
+                .map_err(|err| err.to_string())?;
+            statement.bind((1, session_id.as_str())).map_err(|err| err.to_string())?;
+            match statement.next().map_err(|err| err.to_string())? {
+                State::Row => Ok(Some(SessionRecord {
+                    session: AppSession {
+                        id: statement.read::<String, _>(0).map_err(|err| err.to_string())?,
+                        user_id: statement.read::<String, _>(1).map_err(|err| err.to_string())?,
+                        username: statement.read::<String, _>(8).map_err(|err| err.to_string())?,
+                        created_at: statement.read::<i64, _>(5).map_err(|err| err.to_string())?,
+                        expires_at: statement.read::<i64, _>(6).map_err(|err| err.to_string())?,
+                        last_seen_at: statement.read::<i64, _>(7).map_err(|err| err.to_string())?,
+                        user_agent: statement.read::<String, _>(3).map_err(|err| err.to_string())?,
+                        ip_address: statement.read::<String, _>(4).map_err(|err| err.to_string())?,
+                    },
+                    csrf_token: statement.read::<String, _>(2).map_err(|err| err.to_string())?,
+                    role: AppRole::from(statement.read::<String, _>(9).map_err(|err| err.to_string())?),
+                    disabled: statement.read::<i64, _>(10).map_err(|err| err.to_string())? != 0,
+                })),
+                State::Done => Ok(None),
+            }
+        })
+        .await
+    }
+
+    pub async fn touch_session(&self, session_id: String) -> Result<(), String> {
+        self.with_conn(move |conn| {
+            let mut statement = conn
+                .prepare("UPDATE sessions SET last_seen_at = ?2 WHERE id = ?1")
+                .map_err(|err| err.to_string())?;
+            statement.bind((1, session_id.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((2, crate::nas::crypto::now_ts())).map_err(|err| err.to_string())?;
+            statement.next().map_err(|err| err.to_string())?;
+            Ok(())
+        })
+        .await
+    }
+
+    pub async fn revoke_session(&self, session_id: String) -> Result<(), String> {
+        self.with_conn(move |conn| {
+            let mut statement = conn
+                .prepare("UPDATE sessions SET revoked_at = ?2 WHERE id = ?1")
+                .map_err(|err| err.to_string())?;
+            statement.bind((1, session_id.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((2, crate::nas::crypto::now_ts())).map_err(|err| err.to_string())?;
+            statement.next().map_err(|err| err.to_string())?;
+            Ok(())
+        })
+        .await
+    }
+
+    pub async fn list_sessions(&self) -> Result<Vec<AppSession>, String> {
+        self.with_conn(|conn| {
+            let mut statement = conn
+                .prepare(
+                    "SELECT s.id, s.user_id, u.username, s.created_at, s.expires_at, s.last_seen_at, s.user_agent, s.ip_address
+                     FROM sessions s
+                     JOIN users u ON u.id = s.user_id
+                     WHERE s.revoked_at IS NULL
+                     ORDER BY s.last_seen_at DESC",
+                )
+                .map_err(|err| err.to_string())?;
+            let mut sessions = Vec::new();
+            while let State::Row = statement.next().map_err(|err| err.to_string())? {
+                sessions.push(AppSession {
+                    id: statement.read::<String, _>(0).map_err(|err| err.to_string())?,
+                    user_id: statement.read::<String, _>(1).map_err(|err| err.to_string())?,
+                    username: statement.read::<String, _>(2).map_err(|err| err.to_string())?,
+                    created_at: statement.read::<i64, _>(3).map_err(|err| err.to_string())?,
+                    expires_at: statement.read::<i64, _>(4).map_err(|err| err.to_string())?,
+                    last_seen_at: statement.read::<i64, _>(5).map_err(|err| err.to_string())?,
+                    user_agent: statement.read::<String, _>(6).map_err(|err| err.to_string())?,
+                    ip_address: statement.read::<String, _>(7).map_err(|err| err.to_string())?,
+                });
+            }
+            Ok(sessions)
+        })
+        .await
+    }
+
+    pub async fn create_qr_token(
+        &self,
+        user_id: String,
+        token_hash: String,
+        created_by: String,
+        expires_at: i64,
+    ) -> Result<(), String> {
+        self.with_conn(move |conn| {
+            let qr_id = Uuid::new_v4().to_string();
+            let mut statement = conn
+                .prepare(
+                    "INSERT INTO qr_tokens (id, user_id, token_hash, expires_at, created_at, created_by)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                )
+                .map_err(|err| err.to_string())?;
+            statement.bind((1, qr_id.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((2, user_id.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((3, token_hash.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((4, expires_at)).map_err(|err| err.to_string())?;
+            statement.bind((5, crate::nas::crypto::now_ts())).map_err(|err| err.to_string())?;
+            statement.bind((6, created_by.as_str())).map_err(|err| err.to_string())?;
+            statement.next().map_err(|err| err.to_string())?;
+            Ok(())
+        })
+        .await
+    }
+
+    pub async fn revoke_qr_tokens_for_user(&self, user_id: String) -> Result<(), String> {
+        self.with_conn(move |conn| {
+            let mut statement = conn
+                .prepare("UPDATE qr_tokens SET revoked_at = ?2 WHERE user_id = ?1 AND revoked_at IS NULL")
+                .map_err(|err| err.to_string())?;
+            statement.bind((1, user_id.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((2, crate::nas::crypto::now_ts())).map_err(|err| err.to_string())?;
+            statement.next().map_err(|err| err.to_string())?;
+            Ok(())
+        })
+        .await
+    }
+
+    pub async fn redeem_qr_token(&self, token_hash: String) -> Result<Option<QrRedemption>, String> {
+        self.with_conn(move |conn| {
+            let mut lookup = conn
+                .prepare(
+                    "SELECT user_id, expires_at, max_uses, current_uses, revoked_at
+                     FROM qr_tokens WHERE token_hash = ?1",
+                )
+                .map_err(|err| err.to_string())?;
+            lookup.bind((1, token_hash.as_str())).map_err(|err| err.to_string())?;
+            let (user_id, expires_at, max_uses, current_uses, revoked_at) = match lookup.next().map_err(|err| err.to_string())? {
+                State::Row => (
+                    lookup.read::<String, _>(0).map_err(|err| err.to_string())?,
+                    lookup.read::<i64, _>(1).map_err(|err| err.to_string())?,
+                    lookup.read::<i64, _>(2).map_err(|err| err.to_string())?,
+                    lookup.read::<i64, _>(3).map_err(|err| err.to_string())?,
+                    lookup.read::<Option<i64>, _>(4).map_err(|err| err.to_string())?,
+                ),
+                State::Done => return Ok(None),
+            };
+
+            if revoked_at.is_some() || expires_at < crate::nas::crypto::now_ts() || current_uses >= max_uses {
+                return Ok(None);
+            }
+
+            let mut touch = conn
+                .prepare("UPDATE qr_tokens SET current_uses = current_uses + 1, last_used_at = ?2 WHERE token_hash = ?1")
+                .map_err(|err| err.to_string())?;
+            touch.bind((1, token_hash.as_str())).map_err(|err| err.to_string())?;
+            touch.bind((2, crate::nas::crypto::now_ts())).map_err(|err| err.to_string())?;
+            touch.next().map_err(|err| err.to_string())?;
+
+            let user = get_user(&conn, &user_id)?.ok_or("User not found")?;
+            let permissions = load_permissions(&conn, &user_id)?;
+            Ok(Some(QrRedemption { user, permissions }))
+        })
+        .await
+    }
+
+    pub async fn get_permissions(&self, user_id: String) -> Result<Vec<PermissionAssignment>, String> {
+        self.with_conn(move |conn| load_permissions(&conn, &user_id)).await
+    }
+
+    pub async fn set_permissions(
+        &self,
+        user_id: String,
+        permissions: Vec<PermissionAssignment>,
+    ) -> Result<(), String> {
+        self.with_conn(move |conn| {
+            conn.execute("BEGIN").map_err(|err| err.to_string())?;
+            let mut clear = conn
+                .prepare("DELETE FROM permissions WHERE user_id = ?1")
+                .map_err(|err| err.to_string())?;
+            clear.bind((1, user_id.as_str())).map_err(|err| err.to_string())?;
+            clear.next().map_err(|err| err.to_string())?;
+
+            let now = crate::nas::crypto::now_ts();
+            for permission in permissions {
+                let id = Uuid::new_v4().to_string();
+                let mut statement = conn
+                    .prepare(
+                        "INSERT INTO permissions (id, user_id, folder_id, folder_label, access_level, is_private, created_at, updated_at)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                    )
+                    .map_err(|err| err.to_string())?;
+                statement.bind((1, id.as_str())).map_err(|err| err.to_string())?;
+                statement.bind((2, user_id.as_str())).map_err(|err| err.to_string())?;
+                statement.bind((3, permission.folder_id.as_str())).map_err(|err| err.to_string())?;
+                statement.bind((4, permission.folder_label.as_str())).map_err(|err| err.to_string())?;
+                statement.bind((5, permission.access_level.as_str())).map_err(|err| err.to_string())?;
+                statement.bind((6, if permission.is_private { 1 } else { 0 })).map_err(|err| err.to_string())?;
+                statement.bind((7, now)).map_err(|err| err.to_string())?;
+                statement.bind((8, now)).map_err(|err| err.to_string())?;
+                statement.next().map_err(|err| err.to_string())?;
+            }
+            conn.execute("COMMIT").map_err(|err| err.to_string())?;
+            Ok(())
+        })
+        .await
+    }
+
+    pub async fn store_secret(&self, key: String, value: String) -> Result<(), String> {
+        self.with_conn(move |conn| {
+            let mut statement = conn
+                .prepare(
+                    "INSERT INTO secrets (key, value, updated_at) VALUES (?1, ?2, ?3)
+                     ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+                )
+                .map_err(|err| err.to_string())?;
+            statement.bind((1, key.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((2, value.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((3, crate::nas::crypto::now_ts())).map_err(|err| err.to_string())?;
+            statement.next().map_err(|err| err.to_string())?;
+            Ok(())
+        })
+        .await
+    }
+
+    pub async fn get_secret(&self, key: String) -> Result<Option<String>, String> {
+        self.with_conn(move |conn| {
+            let mut statement = conn
+                .prepare("SELECT value FROM secrets WHERE key = ?1")
+                .map_err(|err| err.to_string())?;
+            statement.bind((1, key.as_str())).map_err(|err| err.to_string())?;
+            match statement.next().map_err(|err| err.to_string())? {
+                State::Row => Ok(Some(statement.read::<String, _>(0).map_err(|err| err.to_string())?)),
+                State::Done => Ok(None),
+            }
+        })
+        .await
+    }
+
+    pub async fn add_audit_log(
+        &self,
+        actor_user_id: Option<String>,
+        action: String,
+        target_type: String,
+        target_id: String,
+        metadata_json: String,
+    ) -> Result<(), String> {
+        self.with_conn(move |conn| {
+            let id = Uuid::new_v4().to_string();
+            let mut statement = conn
+                .prepare(
+                    "INSERT INTO audit_logs (id, actor_user_id, action, target_type, target_id, metadata_json, created_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                )
+                .map_err(|err| err.to_string())?;
+            statement.bind((1, id.as_str())).map_err(|err| err.to_string())?;
+            match actor_user_id {
+                Some(ref value) => statement.bind((2, value.as_str())).map_err(|err| err.to_string())?,
+                None => statement.bind((2, sqlite::Value::Null)).map_err(|err| err.to_string())?,
+            }
+            statement.bind((3, action.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((4, target_type.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((5, target_id.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((6, metadata_json.as_str())).map_err(|err| err.to_string())?;
+            statement.bind((7, crate::nas::crypto::now_ts())).map_err(|err| err.to_string())?;
+            statement.next().map_err(|err| err.to_string())?;
+            Ok(())
+        })
+        .await
+    }
+
+    pub async fn list_audit_logs(&self) -> Result<Vec<AuditEntry>, String> {
+        self.with_conn(|conn| {
+            let mut statement = conn
+                .prepare(
+                    "SELECT id, actor_user_id, action, target_type, target_id, metadata_json, created_at
+                     FROM audit_logs ORDER BY created_at DESC LIMIT 200",
+                )
+                .map_err(|err| err.to_string())?;
+            let mut rows = Vec::new();
+            while let State::Row = statement.next().map_err(|err| err.to_string())? {
+                rows.push(AuditEntry {
+                    id: statement.read::<String, _>(0).map_err(|err| err.to_string())?,
+                    actor_user_id: statement.read::<Option<String>, _>(1).map_err(|err| err.to_string())?,
+                    action: statement.read::<String, _>(2).map_err(|err| err.to_string())?,
+                    target_type: statement.read::<String, _>(3).map_err(|err| err.to_string())?,
+                    target_id: statement.read::<String, _>(4).map_err(|err| err.to_string())?,
+                    metadata_json: statement.read::<String, _>(5).map_err(|err| err.to_string())?,
+                    created_at: statement.read::<i64, _>(6).map_err(|err| err.to_string())?,
+                });
+            }
+            Ok(rows)
+        })
+        .await
+    }
+}
+
+fn get_user(conn: &Connection, user_id: &str) -> Result<Option<AppUser>, String> {
+    let mut statement = conn
+        .prepare(
+            "SELECT id, username, display_name, role_id, disabled, created_at
+             FROM users WHERE id = ?1",
+        )
+        .map_err(|err| err.to_string())?;
+    statement.bind((1, user_id)).map_err(|err| err.to_string())?;
+    match statement.next().map_err(|err| err.to_string())? {
+        State::Row => Ok(Some(AppUser {
+            id: statement.read::<String, _>(0).map_err(|err| err.to_string())?,
+            username: statement.read::<String, _>(1).map_err(|err| err.to_string())?,
+            display_name: statement.read::<String, _>(2).map_err(|err| err.to_string())?,
+            role: AppRole::from(statement.read::<String, _>(3).map_err(|err| err.to_string())?),
+            disabled: statement.read::<i64, _>(4).map_err(|err| err.to_string())? != 0,
+            created_at: statement.read::<i64, _>(5).map_err(|err| err.to_string())?,
+        })),
+        State::Done => Ok(None),
+    }
+}
+
+fn load_permissions(conn: &Connection, user_id: &str) -> Result<Vec<PermissionAssignment>, String> {
+    let mut statement = conn
+        .prepare(
+            "SELECT folder_id, folder_label, access_level, is_private
+             FROM permissions WHERE user_id = ?1 ORDER BY folder_label ASC",
+        )
+        .map_err(|err| err.to_string())?;
+    statement.bind((1, user_id)).map_err(|err| err.to_string())?;
+    let mut permissions = Vec::new();
+    while let State::Row = statement.next().map_err(|err| err.to_string())? {
+        permissions.push(PermissionAssignment {
+            folder_id: statement.read::<String, _>(0).map_err(|err| err.to_string())?,
+            folder_label: statement.read::<String, _>(1).map_err(|err| err.to_string())?,
+            access_level: AccessLevel::from(statement.read::<String, _>(2).map_err(|err| err.to_string())?),
+            is_private: statement.read::<i64, _>(3).map_err(|err| err.to_string())? != 0,
+        });
+    }
+    Ok(permissions)
+}
+
+fn execute_bind3(conn: &Connection, sql: &str, a: &str, b: &str, c: &str) -> Result<(), String> {
+    let mut statement = conn.prepare(sql).map_err(|err| err.to_string())?;
+    statement.bind((1, a)).map_err(|err| err.to_string())?;
+    statement.bind((2, b)).map_err(|err| err.to_string())?;
+    statement.bind((3, c)).map_err(|err| err.to_string())?;
+    statement.next().map_err(|err| err.to_string())?;
+    Ok(())
+}

--- a/app/src-tauri/src/nas/mod.rs
+++ b/app/src-tauri/src/nas/mod.rs
@@ -1,0 +1,5 @@
+pub mod api;
+pub mod crypto;
+pub mod db;
+pub mod models;
+pub mod state;

--- a/app/src-tauri/src/nas/models.rs
+++ b/app/src-tauri/src/nas/models.rs
@@ -1,0 +1,172 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AppRole {
+    Admin,
+    User,
+}
+
+impl AppRole {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Admin => "admin",
+            Self::User => "user",
+        }
+    }
+}
+
+impl From<String> for AppRole {
+    fn from(value: String) -> Self {
+        match value.as_str() {
+            "admin" => Self::Admin,
+            _ => Self::User,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SystemStatus {
+    pub setup_required: bool,
+    pub owner_configured: bool,
+    pub owner_connected: bool,
+    pub api_base_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BootstrapRequest {
+    pub username: String,
+    pub password: String,
+    pub display_name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoginRequest {
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OwnerConfigRequest {
+    pub api_id: i32,
+    pub api_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserUpsertRequest {
+    pub username: String,
+    pub password: Option<String>,
+    pub display_name: String,
+    pub disabled: bool,
+    pub role: AppRole,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserPatchRequest {
+    pub display_name: Option<String>,
+    pub disabled: Option<bool>,
+    pub role: Option<AppRole>,
+    pub password: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PermissionAssignment {
+    pub folder_id: String,
+    pub folder_label: String,
+    pub access_level: AccessLevel,
+    pub is_private: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AccessLevel {
+    ReadOnly,
+    ReadWrite,
+}
+
+impl AccessLevel {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ReadOnly => "read_only",
+            Self::ReadWrite => "read_write",
+        }
+    }
+}
+
+impl From<String> for AccessLevel {
+    fn from(value: String) -> Self {
+        match value.as_str() {
+            "read_write" => Self::ReadWrite,
+            _ => Self::ReadOnly,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PermissionUpdateRequest {
+    pub permissions: Vec<PermissionAssignment>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoginResponse {
+    pub user: AppUser,
+    pub csrf_token: String,
+    pub access_token: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppUser {
+    pub id: String,
+    pub username: String,
+    pub display_name: String,
+    pub role: AppRole,
+    pub disabled: bool,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppSession {
+    pub id: String,
+    pub user_id: String,
+    pub username: String,
+    pub created_at: i64,
+    pub expires_at: i64,
+    pub last_seen_at: i64,
+    pub user_agent: String,
+    pub ip_address: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QrTokenResponse {
+    pub token: String,
+    pub login_url: String,
+    pub expires_at: i64,
+    pub user_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeResponse {
+    pub user: AppUser,
+    pub permissions: Vec<PermissionAssignment>,
+    pub owner_connected: bool,
+    pub csrf_token: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditEntry {
+    pub id: String,
+    pub actor_user_id: Option<String>,
+    pub action: String,
+    pub target_type: String,
+    pub target_id: String,
+    pub metadata_json: String,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthClaims {
+    pub sub: String,
+    pub sid: String,
+    pub role: String,
+    pub exp: usize,
+}

--- a/app/src-tauri/src/nas/state.rs
+++ b/app/src-tauri/src/nas/state.rs
@@ -1,0 +1,71 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use crate::commands::TelegramState;
+
+use super::crypto::{decode_jwt, ensure_master_key, issue_jwt};
+use super::db::Database;
+use super::models::AuthClaims;
+
+#[derive(Clone)]
+pub struct NasState {
+    pub db: Database,
+    pub app_data_dir: PathBuf,
+    pub master_key: Arc<Vec<u8>>,
+    pub jwt_key: Arc<Vec<u8>>,
+    pub session_cookie_name: String,
+    pub api_base_url: String,
+    pub rate_limits: Arc<Mutex<HashMap<String, Vec<i64>>>>,
+    pub telegram: Arc<TelegramState>,
+}
+
+impl NasState {
+    pub async fn new(
+        app_data_dir: PathBuf,
+        api_base_url: String,
+        telegram: Arc<TelegramState>,
+    ) -> Result<Self, String> {
+        std::fs::create_dir_all(&app_data_dir).map_err(|err| err.to_string())?;
+
+        let db = Database::new(app_data_dir.join("telegram_nas.sqlite3")).await?;
+        let master_key = ensure_master_key(&app_data_dir.join("master.key"))?;
+        let jwt_key = ensure_master_key(&app_data_dir.join("jwt.key"))?;
+
+        Ok(Self {
+            db,
+            app_data_dir,
+            master_key: Arc::new(master_key),
+            jwt_key: Arc::new(jwt_key),
+            session_cookie_name: "td_session".to_string(),
+            api_base_url,
+            rate_limits: Arc::new(Mutex::new(HashMap::new())),
+            telegram,
+        })
+    }
+
+    pub fn issue_session_jwt(
+        &self,
+        claims: &AuthClaims,
+    ) -> Result<String, String> {
+        issue_jwt(claims, self.jwt_key.as_ref())
+    }
+
+    pub fn decode_session_jwt(&self, token: &str) -> Result<AuthClaims, String> {
+        decode_jwt(token, self.jwt_key.as_ref())
+    }
+
+    pub async fn allow_rate(&self, key: String, limit: usize, window_seconds: i64) -> bool {
+        let now = crate::nas::crypto::now_ts();
+        let mut guard = self.rate_limits.lock().await;
+        let entries = guard.entry(key).or_default();
+        entries.retain(|ts| *ts > now - window_seconds);
+        if entries.len() >= limit {
+            return false;
+        }
+        entries.push(now);
+        true
+    }
+}

--- a/app/src-tauri/src/server.rs
+++ b/app/src-tauri/src/server.rs
@@ -1,7 +1,7 @@
 use actix_web::{get, web, App, HttpServer, HttpResponse, Responder};
 use actix_cors::Cors;
 use crate::commands::TelegramState;
-use crate::commands::utils::resolve_peer;
+use crate::commands::utils::resolve_peer_ref;
 use grammers_client::types::Media;
 
 use std::sync::Arc;
@@ -59,7 +59,7 @@ async fn stream_media(
 
     if let Some(client) = client_opt {
         log::debug!("Stream request: Client acquired, resolving peer for msg {}...", message_id);
-        match resolve_peer(&client, folder_id, &data.peer_cache).await {
+        match resolve_peer_ref(&client, folder_id, &data.peer_cache).await {
             Ok(peer) => {
                 log::debug!("Stream request: Peer resolved, fetching message {}...", message_id);
                 // Try to fetch message efficiently

--- a/app/src-tauri/src/server.rs
+++ b/app/src-tauri/src/server.rs
@@ -1,10 +1,8 @@
 use actix_web::{get, web, App, HttpServer, HttpResponse, Responder};
 use actix_cors::Cors;
-use crate::commands::TelegramState;
 use crate::commands::utils::resolve_peer;
 use grammers_client::types::Media;
-
-use std::sync::Arc;
+use crate::nas::{api::configure_api, state::NasState};
 
 /// Holds the per-session streaming token for Actix validation
 pub struct StreamTokenData {
@@ -20,7 +18,7 @@ struct StreamQuery {
 async fn stream_media(
     path: web::Path<(String, i32)>,
     query: web::Query<StreamQuery>,
-    data: web::Data<Arc<TelegramState>>,
+    data: web::Data<NasState>,
     token_data: web::Data<StreamTokenData>,
 ) -> impl Responder {
     let (folder_id_str, message_id) = path.into_inner();
@@ -54,12 +52,12 @@ async fn stream_media(
     };
 
     let client_opt = {
-        data.client.lock().await.clone()
+        data.telegram.client.lock().await.clone()
     };
 
     if let Some(client) = client_opt {
         log::debug!("Stream request: Client acquired, resolving peer for msg {}...", message_id);
-        match resolve_peer(&client, folder_id, &data.peer_cache).await {
+        match resolve_peer(&client, folder_id, &data.telegram.peer_cache).await {
             Ok(peer) => {
                 log::debug!("Stream request: Peer resolved, fetching message {}...", message_id);
                 // Try to fetch message efficiently
@@ -137,7 +135,7 @@ fn mime_type_from_media(media: &Media) -> String {
     }
 }
 
-pub async fn start_server(state: Arc<TelegramState>, port: u16, token: String) -> std::io::Result<actix_web::dev::Server> {
+pub async fn start_server(state: NasState, port: u16, token: String) -> std::io::Result<actix_web::dev::Server> {
     let state_data = web::Data::new(state);
     let token_data = web::Data::new(StreamTokenData { token });
     
@@ -146,8 +144,11 @@ pub async fn start_server(state: Arc<TelegramState>, port: u16, token: String) -
     let server = HttpServer::new(move || {
         let cors = Cors::default()
             .allowed_origin("tauri://localhost")
+            .allowed_origin("http://tauri.localhost")
             .allowed_origin("http://localhost:1420")
             .allowed_origin("https://tauri.localhost")
+            .allowed_origin("http://127.0.0.1:1420")
+            .supports_credentials()
             .allow_any_method()
             .allow_any_header();
 
@@ -155,12 +156,13 @@ pub async fn start_server(state: Arc<TelegramState>, port: u16, token: String) -
             .wrap(cors)
             .app_data(state_data.clone())
             .app_data(token_data.clone())
+            .configure(configure_api)
             .service(stream_media)
     })
-    .bind(("127.0.0.1", port))?
+    .bind(("0.0.0.0", port))?
     .run();
 
-    log::info!("Streaming Server started successfully on http://127.0.0.1:{}", port);
+    log::info!("Telegram NAS API started successfully on http://0.0.0.0:{}", port);
 
     Ok(server)
 }

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' http://localhost:14201; media-src 'self' http://localhost:14201; img-src 'self' data: blob: asset: https://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self'; worker-src 'self' blob:;",
+      "csp": "default-src 'self'; connect-src 'self' http://localhost:14201 http://127.0.0.1:14201; media-src 'self' http://localhost:14201 http://127.0.0.1:14201; img-src 'self' data: blob: asset: https://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self'; worker-src 'self' blob:;",
       "capabilities": [
         "default"
       ]

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,26 +1,94 @@
-import { useState } from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { AuthWizard } from "./components/AuthWizard";
-import { Dashboard } from "./components/Dashboard";
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { QueryClient, QueryClientProvider, useQuery, useQueryClient } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
+import { QRCodeSVG } from "qrcode.react";
+import { Shield, UserPlus, Users, History, KeyRound, ScanQrCode, HardDrive, LogOut } from "lucide-react";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { Dashboard } from "./components/Dashboard";
 import { UpdateBanner } from "./components/UpdateBanner";
 import { useUpdateCheck } from "./hooks/useUpdateCheck";
-import "./App.css";
-
-import { Toaster } from "sonner";
+import { nasApi, nasSession } from "./lib/nasApi";
 import { ConfirmProvider } from "./context/ConfirmContext";
 import { ThemeProvider, useTheme } from "./context/ThemeContext";
 import { DropZoneProvider } from "./contexts/DropZoneContext";
+import { Toaster, toast } from "sonner";
+import type {
+  AppSession,
+  AppUser,
+  AuditEntry,
+  MeResponse,
+  PermissionAssignment,
+  QrTokenResponse,
+  SystemStatus,
+} from "./types/nas";
+import type { TelegramFolder } from "./types";
+import "./App.css";
 
 const queryClient = new QueryClient();
 
 function AppContent() {
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [csrfToken, setCsrfToken] = useState<string | null>(null);
   const { theme } = useTheme();
   const { available, version, downloading, progress, downloadAndInstall, dismissUpdate } = useUpdateCheck();
+  const client = useQueryClient();
+  const qrToken = useMemo(() => new URLSearchParams(window.location.search).get("qr"), []);
+
+  const systemQuery = useQuery({
+    queryKey: ["system-status"],
+    queryFn: nasApi.systemStatus,
+    retry: false,
+  });
+
+  const meQuery = useQuery({
+    queryKey: ["auth-me"],
+    queryFn: nasApi.me,
+    retry: false,
+    enabled: !systemQuery.data?.setup_required,
+  });
+
+  const finishLogin = (response: { csrf_token: string; access_token: string }) => {
+    nasSession.setAccessToken(response.access_token);
+    setCsrfToken(response.csrf_token);
+    client.invalidateQueries({ queryKey: ["auth-me"] });
+    client.invalidateQueries({ queryKey: ["system-status"] });
+  };
+
+  const handleLogout = async () => {
+    try {
+      await nasApi.logout(csrfToken || undefined);
+    } finally {
+      nasSession.clearAccessToken();
+      setCsrfToken(null);
+      client.removeQueries({ queryKey: ["auth-me"] });
+      client.invalidateQueries({ queryKey: ["system-status"] });
+    }
+  };
+
+  useEffect(() => {
+    if (qrToken && !meQuery.data && !systemQuery.data?.setup_required) {
+      nasApi
+        .redeemQr(qrToken)
+        .then((response) => {
+          finishLogin(response);
+          window.history.replaceState({}, "", window.location.pathname);
+          toast.success("QR login complete");
+        })
+        .catch((error) => {
+          toast.error(error.message || "QR login failed");
+        });
+    }
+  }, [qrToken, meQuery.data, systemQuery.data?.setup_required]);
+
+  useEffect(() => {
+    if (meQuery.data?.csrf_token) {
+      setCsrfToken(meQuery.data.csrf_token);
+    }
+  }, [meQuery.data?.csrf_token]);
+
+  const isLoading = systemQuery.isLoading || (meQuery.isLoading && !systemQuery.data?.setup_required);
 
   return (
-    <main className="h-screen w-screen text-telegram-text overflow-hidden selection:bg-telegram-primary/30 relative">
+    <main className="h-screen w-screen overflow-hidden bg-[radial-gradient(circle_at_top_left,_#142238,_#08101d_55%,_#050810)] text-white">
       <UpdateBanner
         available={available}
         version={version}
@@ -30,15 +98,674 @@ function AppContent() {
         onDismiss={dismissUpdate}
       />
       <Toaster theme={theme} position="bottom-center" />
-      {isAuthenticated ? (
-        <Dashboard onLogout={() => setIsAuthenticated(false)} />
+
+      {isLoading ? (
+        <CenteredCard title="Preparing Telegram NAS" subtitle="Loading the auth and owner-session state..." />
+      ) : systemQuery.error ? (
+        <CenteredCard title="Backend Unavailable" subtitle={(systemQuery.error as Error).message} />
+      ) : systemQuery.data?.setup_required ? (
+        <BootstrapPage onBootstrapped={finishLogin} />
+      ) : !meQuery.data ? (
+        <LoginPage onLoggedIn={finishLogin} qrToken={qrToken} />
+      ) : meQuery.data.user.role === "admin" ? (
+        <AdminConsole
+          csrfToken={csrfToken}
+          me={meQuery.data}
+          systemStatus={systemQuery.data!}
+          onLogout={handleLogout}
+        />
       ) : (
-        <AuthWizard onLogin={() => setIsAuthenticated(true)} />
+        <UserHome me={meQuery.data} onLogout={handleLogout} />
       )}
     </main>
   );
 }
 
+function CenteredCard({ title, subtitle }: { title: string; subtitle: string }) {
+  return (
+    <div className="flex h-full items-center justify-center p-6">
+      <div className="w-full max-w-xl rounded-[32px] border border-white/10 bg-white/6 p-10 backdrop-blur-xl">
+        <div className="mb-4 inline-flex rounded-full border border-cyan-400/30 bg-cyan-400/10 p-3 text-cyan-300">
+          <Shield className="h-6 w-6" />
+        </div>
+        <h1 className="text-3xl font-semibold tracking-tight">{title}</h1>
+        <p className="mt-3 text-sm text-slate-300">{subtitle}</p>
+      </div>
+    </div>
+  );
+}
+
+function BootstrapPage({ onBootstrapped }: { onBootstrapped: (response: { csrf_token: string; access_token: string }) => void }) {
+  const [username, setUsername] = useState("admin");
+  const [displayName, setDisplayName] = useState("NAS Owner");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setLoading(true);
+    try {
+      const response = await nasApi.bootstrap({
+        username,
+        password,
+        display_name: displayName,
+      });
+      onBootstrapped(response);
+      toast.success("Admin account created");
+    } catch (error) {
+      toast.error((error as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full items-center justify-center p-6">
+      <form onSubmit={handleSubmit} className="w-full max-w-3xl rounded-[36px] border border-white/10 bg-black/25 p-8 shadow-2xl backdrop-blur-2xl">
+        <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+          <div>
+            <p className="mb-3 text-xs uppercase tracking-[0.32em] text-cyan-300">First Launch</p>
+            <h1 className="text-4xl font-semibold tracking-tight">Bootstrap the self-hosted Telegram NAS</h1>
+            <p className="mt-4 max-w-xl text-sm leading-7 text-slate-300">
+              This one-time wizard creates the local admin account. Telegram owner credentials are configured later inside the protected admin console, not on the public login screen.
+            </p>
+          </div>
+          <div className="space-y-4 rounded-[28px] border border-white/8 bg-white/5 p-6">
+            <Field label="Admin username" value={username} onChange={setUsername} />
+            <Field label="Display name" value={displayName} onChange={setDisplayName} />
+            <Field label="Password" type="password" value={password} onChange={setPassword} />
+            <button disabled={loading} className="w-full rounded-2xl bg-cyan-400 px-4 py-3 font-medium text-slate-950 transition hover:bg-cyan-300 disabled:opacity-60">
+              {loading ? "Creating admin..." : "Create Admin"}
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function LoginPage({
+  onLoggedIn,
+  qrToken,
+}: {
+  onLoggedIn: (response: { csrf_token: string; access_token: string }) => void;
+  qrToken: string | null;
+}) {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setLoading(true);
+    try {
+      const response = await nasApi.login({ username, password });
+      onLoggedIn(response);
+      toast.success("Signed in");
+    } catch (error) {
+      toast.error((error as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full items-center justify-center p-6">
+      <div className="grid w-full max-w-5xl gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+        <div className="rounded-[36px] border border-white/10 bg-white/6 p-8 backdrop-blur-xl">
+          <p className="mb-3 text-xs uppercase tracking-[0.32em] text-cyan-300">Access Portal</p>
+          <h1 className="text-4xl font-semibold tracking-tight">Internal app authentication only</h1>
+          <p className="mt-4 max-w-2xl text-sm leading-7 text-slate-300">
+            Users sign into this NAS directly. Telegram API ID, API Hash, and MTProto login are reserved for the owner’s secure admin console.
+          </p>
+          <div className="mt-8 grid gap-4 sm:grid-cols-2">
+            <Feature icon={Users} title="Multi-user roles" copy="Admin and user access is split cleanly from the shared Telegram owner session." />
+            <Feature icon={ScanQrCode} title="QR login" copy="Provision mobile access with revokable short-lived QR tokens instead of sharing credentials." />
+          </div>
+        </div>
+        <form onSubmit={handleSubmit} className="rounded-[36px] border border-white/10 bg-black/25 p-8 backdrop-blur-2xl">
+          <Field label="Username" value={username} onChange={setUsername} />
+          <Field label="Password" type="password" value={password} onChange={setPassword} />
+          <button disabled={loading} className="mt-4 w-full rounded-2xl bg-cyan-400 px-4 py-3 font-medium text-slate-950 transition hover:bg-cyan-300 disabled:opacity-60">
+            {loading ? "Signing in..." : "Sign In"}
+          </button>
+          {qrToken && <p className="mt-4 text-sm text-cyan-300">A QR token was detected in the URL. The app will try that flow automatically.</p>}
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function AdminConsole({
+  csrfToken,
+  me,
+  systemStatus,
+  onLogout,
+}: {
+  csrfToken: string | null;
+  me: MeResponse;
+  systemStatus: SystemStatus;
+  onLogout: () => void;
+}) {
+  const [tab, setTab] = useState<"owner" | "users" | "sessions" | "audit" | "storage">("owner");
+  const tabs = [
+    { id: "owner", label: "Owner Session", icon: KeyRound },
+    { id: "users", label: "Users", icon: Users },
+    { id: "sessions", label: "Sessions", icon: History },
+    { id: "audit", label: "Audit", icon: Shield },
+    { id: "storage", label: "Storage", icon: HardDrive },
+  ] as const;
+
+  if (tab === "storage") {
+    return (
+      <Dashboard
+        onLogout={onLogout}
+        adminControls={{ onAdminBack: () => setTab("owner") }}
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="border-b border-white/10 bg-black/20 px-6 py-4 backdrop-blur-xl">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-[0.32em] text-cyan-300">Admin Console</p>
+            <h1 className="text-2xl font-semibold">Telegram NAS control plane</h1>
+            <p className="mt-1 text-sm text-slate-300">
+              Signed in as {me.user.display_name}. Owner Telegram session is {systemStatus.owner_connected ? "connected" : "waiting"}.
+            </p>
+          </div>
+          <button onClick={onLogout} className="rounded-2xl border border-white/10 px-4 py-2 text-sm text-slate-200 transition hover:bg-white/8">
+            <span className="inline-flex items-center gap-2"><LogOut className="h-4 w-4" /> Sign Out</span>
+          </button>
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2">
+          {tabs.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => setTab(item.id)}
+              className={`rounded-full px-4 py-2 text-sm transition ${tab === item.id ? "bg-cyan-400 text-slate-950" : "border border-white/10 bg-white/5 text-slate-200 hover:bg-white/8"}`}
+            >
+              <span className="inline-flex items-center gap-2"><item.icon className="h-4 w-4" /> {item.label}</span>
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <section className="min-h-0 flex-1 overflow-auto p-6">
+        {tab === "owner" && <OwnerTelegramPanel csrfToken={csrfToken} />}
+        {tab === "users" && <UsersPanel csrfToken={csrfToken} />}
+        {tab === "sessions" && <SessionsPanel csrfToken={csrfToken} />}
+        {tab === "audit" && <AuditPanel />}
+      </section>
+    </div>
+  );
+}
+
+function OwnerTelegramPanel({ csrfToken }: { csrfToken: string | null }) {
+  const [apiId, setApiId] = useState("");
+  const [apiHash, setApiHash] = useState("");
+  const [phone, setPhone] = useState("");
+  const [code, setCode] = useState("");
+  const [password, setPassword] = useState("");
+  const [step, setStep] = useState<"config" | "code" | "password">("config");
+  const ownerStatus = useQuery({
+    queryKey: ["owner-status"],
+    queryFn: nasApi.ownerStatus,
+    retry: false,
+  });
+
+  useEffect(() => {
+    if (ownerStatus.data?.api_id) {
+      setApiId(ownerStatus.data.api_id);
+    }
+  }, [ownerStatus.data?.api_id]);
+
+  const saveOwnerConfig = async () => {
+    if (!csrfToken) return;
+    await nasApi.saveOwnerConfig({ api_id: Number(apiId), api_hash: apiHash }, csrfToken);
+  };
+
+  const requestCode = async () => {
+    try {
+      await saveOwnerConfig();
+      await invoke("cmd_auth_request_code", { phone, apiId: Number(apiId), apiHash });
+      setStep("code");
+      toast.success("Telegram code requested");
+    } catch (error) {
+      toast.error((error as Error).message);
+    }
+  };
+
+  const completeCode = async () => {
+    try {
+      const response = await invoke<{ success: boolean; next_step?: string }>("cmd_auth_sign_in", { code });
+      if (response.success) {
+        toast.success("Owner Telegram session connected");
+        ownerStatus.refetch();
+      } else if (response.next_step === "password") {
+        setStep("password");
+      }
+    } catch (error) {
+      toast.error((error as Error).message);
+    }
+  };
+
+  const completePassword = async () => {
+    try {
+      await invoke("cmd_auth_check_password", { password });
+      toast.success("Owner Telegram session connected");
+      ownerStatus.refetch();
+    } catch (error) {
+      toast.error((error as Error).message);
+    }
+  };
+
+  return (
+    <div className="grid gap-6 xl:grid-cols-[0.9fr_1.1fr]">
+      <div className="rounded-[32px] border border-white/10 bg-white/6 p-6">
+        <p className="text-xs uppercase tracking-[0.32em] text-cyan-300">Owner Session</p>
+        <h2 className="mt-2 text-2xl font-semibold">One Telegram account for the whole NAS</h2>
+        <p className="mt-4 text-sm leading-7 text-slate-300">
+          Configure the owner account once. Normal users never see API credentials or MTProto login prompts.
+        </p>
+        <div className="mt-6 rounded-3xl border border-white/10 bg-black/20 p-4 text-sm">
+          <p>Configured: <strong>{ownerStatus.data?.configured ? "Yes" : "No"}</strong></p>
+          <p>Connected: <strong>{ownerStatus.data?.connected ? "Yes" : "No"}</strong></p>
+        </div>
+      </div>
+      <div className="rounded-[32px] border border-white/10 bg-black/25 p-6">
+        <div className="grid gap-4 md:grid-cols-2">
+          <Field label="Telegram API ID" value={apiId} onChange={setApiId} />
+          <Field label="Telegram API Hash" value={apiHash} onChange={setApiHash} />
+          <Field label="Phone number" value={phone} onChange={setPhone} />
+          <div className="flex items-end">
+            <button onClick={requestCode} className="w-full rounded-2xl bg-cyan-400 px-4 py-3 font-medium text-slate-950 transition hover:bg-cyan-300">
+              Save & Request Code
+            </button>
+          </div>
+        </div>
+        {step === "code" && (
+          <div className="mt-6 grid gap-4 md:grid-cols-[1fr_auto]">
+            <Field label="Telegram code" value={code} onChange={setCode} />
+            <div className="flex items-end">
+              <button onClick={completeCode} className="rounded-2xl border border-white/10 px-4 py-3 text-sm transition hover:bg-white/8">Verify Code</button>
+            </div>
+          </div>
+        )}
+        {step === "password" && (
+          <div className="mt-6 grid gap-4 md:grid-cols-[1fr_auto]">
+            <Field label="2FA password" type="password" value={password} onChange={setPassword} />
+            <div className="flex items-end">
+              <button onClick={completePassword} className="rounded-2xl border border-white/10 px-4 py-3 text-sm transition hover:bg-white/8">Verify Password</button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function UsersPanel({ csrfToken }: { csrfToken: string | null }) {
+  const client = useQueryClient();
+  const users = useQuery({ queryKey: ["admin-users"], queryFn: nasApi.listUsers, retry: false });
+  const [draft, setDraft] = useState<{ username: string; password: string; display_name: string; disabled: boolean; role: "admin" | "user" }>({
+    username: "",
+    password: "",
+    display_name: "",
+    disabled: false,
+    role: "user",
+  });
+  const [selectedUser, setSelectedUser] = useState<AppUser | null>(null);
+  const [qr, setQr] = useState<QrTokenResponse | null>(null);
+  const permissions = useQuery({
+    queryKey: ["user-permissions", selectedUser?.id],
+    queryFn: () => nasApi.getPermissions(selectedUser!.id),
+    enabled: !!selectedUser,
+  });
+  const folderCatalog = useQuery({
+    queryKey: ["telegram-folder-catalog"],
+    queryFn: async () => {
+      try {
+        return await invoke<TelegramFolder[]>("cmd_scan_folders");
+      } catch {
+        return [];
+      }
+    },
+    enabled: !!selectedUser,
+  });
+  const [permissionDraft, setPermissionDraft] = useState<PermissionAssignment[]>([]);
+
+  useEffect(() => {
+    setPermissionDraft(permissions.data || []);
+  }, [permissions.data]);
+
+  const availableFolders = useMemo(
+    () => [
+      { id: "root", name: "Saved Messages" },
+      ...(folderCatalog.data || []).map((folder) => ({
+        id: String(folder.id),
+        name: folder.name,
+      })),
+    ],
+    [folderCatalog.data]
+  );
+
+  const setFolderPermission = (
+    folder: { id: string; name: string },
+    enabled: boolean,
+    accessLevel: PermissionAssignment["access_level"] = "read_write"
+  ) => {
+    setPermissionDraft((current) => {
+      if (!enabled) {
+        return current.filter((permission) => permission.folder_id !== folder.id);
+      }
+
+      const existing = current.find((permission) => permission.folder_id === folder.id);
+      if (existing) {
+        return current.map((permission) =>
+          permission.folder_id === folder.id
+            ? { ...permission, folder_label: folder.name, access_level: accessLevel }
+            : permission
+        );
+      }
+
+      return [
+        ...current,
+        {
+          folder_id: folder.id,
+          folder_label: folder.name,
+          access_level: accessLevel,
+          is_private: false,
+        },
+      ];
+    });
+  };
+
+  const refresh = () => {
+    client.invalidateQueries({ queryKey: ["admin-users"] });
+    if (selectedUser) client.invalidateQueries({ queryKey: ["user-permissions", selectedUser.id] });
+  };
+
+  const createUser = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!csrfToken) return;
+    try {
+      await nasApi.createUser(draft, csrfToken);
+      setDraft({ username: "", password: "", display_name: "", disabled: false, role: "user" });
+      refresh();
+      toast.success("User created");
+    } catch (error) {
+      toast.error((error as Error).message);
+    }
+  };
+
+  const savePermissions = async () => {
+    if (!csrfToken || !selectedUser) return;
+    try {
+      await nasApi.setPermissions(selectedUser.id, permissionDraft, csrfToken);
+      refresh();
+      toast.success("Permissions updated");
+    } catch (error) {
+      toast.error((error as Error).message);
+    }
+  };
+
+  return (
+    <div className="grid gap-6 xl:grid-cols-[0.8fr_1.2fr]">
+      <form onSubmit={createUser} className="rounded-[32px] border border-white/10 bg-black/25 p-6">
+        <p className="text-xs uppercase tracking-[0.32em] text-cyan-300">Create User</p>
+        <div className="mt-4 space-y-4">
+          <Field label="Username" value={draft.username} onChange={(value) => setDraft((prev) => ({ ...prev, username: value }))} />
+          <Field label="Display name" value={draft.display_name} onChange={(value) => setDraft((prev) => ({ ...prev, display_name: value }))} />
+          <Field label="Password" type="password" value={draft.password} onChange={(value) => setDraft((prev) => ({ ...prev, password: value }))} />
+          <label className="block text-sm">
+            <span className="mb-2 block text-slate-300">Role</span>
+            <select value={draft.role} onChange={(event) => setDraft((prev) => ({ ...prev, role: event.target.value as "admin" | "user" }))} className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 outline-none">
+              <option value="user">User</option>
+              <option value="admin">Admin</option>
+            </select>
+          </label>
+          <button className="w-full rounded-2xl bg-cyan-400 px-4 py-3 font-medium text-slate-950 transition hover:bg-cyan-300">
+            <span className="inline-flex items-center gap-2"><UserPlus className="h-4 w-4" /> Create User</span>
+          </button>
+        </div>
+      </form>
+
+      <div className="space-y-6">
+        <div className="rounded-[32px] border border-white/10 bg-white/6 p-6">
+          <p className="text-xs uppercase tracking-[0.32em] text-cyan-300">Users</p>
+          <div className="mt-4 grid gap-3">
+            {users.data?.map((user) => (
+              <button key={user.id} onClick={() => { setSelectedUser(user); setPermissionDraft([]); setQr(null); }} className="rounded-2xl border border-white/10 bg-black/25 p-4 text-left transition hover:bg-white/8">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="font-medium">{user.display_name}</p>
+                    <p className="text-sm text-slate-300">@{user.username} · {user.role}</p>
+                  </div>
+                  <span className={`rounded-full px-3 py-1 text-xs ${user.disabled ? "bg-red-500/20 text-red-200" : "bg-emerald-500/20 text-emerald-200"}`}>
+                    {user.disabled ? "Disabled" : "Active"}
+                  </span>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {selectedUser && (
+          <div className="rounded-[32px] border border-white/10 bg-black/25 p-6">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="text-lg font-semibold">{selectedUser.display_name}</p>
+                <p className="text-sm text-slate-300">@{selectedUser.username}</p>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={async () => {
+                    if (!csrfToken) return;
+                    const qrResponse = await nasApi.generateQr(selectedUser.id, csrfToken);
+                    setQr(qrResponse);
+                  }}
+                  className="rounded-2xl border border-white/10 px-4 py-2 text-sm transition hover:bg-white/8"
+                >
+                  Generate QR
+                </button>
+                <button
+                  onClick={async () => {
+                    if (!csrfToken) return;
+                    await nasApi.revokeQr(selectedUser.id, csrfToken);
+                    setQr(null);
+                    toast.success("QR tokens revoked");
+                  }}
+                  className="rounded-2xl border border-white/10 px-4 py-2 text-sm transition hover:bg-white/8"
+                >
+                  Revoke QR
+                </button>
+              </div>
+            </div>
+
+            {qr && (
+              <div className="mt-6 rounded-3xl border border-white/10 bg-white/5 p-5">
+                <div className="flex flex-col gap-4 md:flex-row md:items-center">
+                  <QRCodeSVG value={qr.login_url} size={160} bgColor="transparent" fgColor="#ffffff" />
+                  <div className="text-sm text-slate-300">
+                    <p className="font-medium text-white">Provisioning QR</p>
+                    <p className="mt-2 break-all">{qr.login_url}</p>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div className="mt-6">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-medium text-white">Folder permissions</p>
+                  <p className="mt-2 text-xs leading-6 text-slate-400">
+                    Pick the Telegram folders this user can open. Read-write users can upload and move files, but normal users still cannot delete admin-created folders.
+                  </p>
+                </div>
+                <button
+                  onClick={() => folderCatalog.refetch()}
+                  className="rounded-2xl border border-white/10 px-4 py-2 text-sm text-slate-200 transition hover:bg-white/8"
+                >
+                  Refresh Folders
+                </button>
+              </div>
+
+              <div className="mt-4 max-h-80 space-y-3 overflow-auto rounded-3xl border border-white/10 bg-white/5 p-3">
+                {availableFolders.map((folder) => {
+                  const permission = permissionDraft.find((item) => item.folder_id === folder.id);
+                  const enabled = Boolean(permission);
+
+                  return (
+                    <div key={folder.id} className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-white/8 bg-black/20 p-3">
+                      <label className="flex min-w-0 flex-1 items-center gap-3 text-sm">
+                        <input
+                          type="checkbox"
+                          checked={enabled}
+                          onChange={(event) => setFolderPermission(folder, event.target.checked)}
+                          className="h-4 w-4 accent-cyan-400"
+                        />
+                        <span className="min-w-0">
+                          <span className="block truncate font-medium text-white">{folder.name}</span>
+                          <span className="block truncate text-xs text-slate-400">{folder.id === "root" ? "Owner Saved Messages" : `Telegram folder ${folder.id}`}</span>
+                        </span>
+                      </label>
+                      <select
+                        disabled={!enabled}
+                        value={permission?.access_level || "read_write"}
+                        onChange={(event) => setFolderPermission(folder, true, event.target.value as PermissionAssignment["access_level"])}
+                        className="rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-white outline-none disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        <option value="read_write">Read + Write</option>
+                        <option value="read_only">Read Only</option>
+                      </select>
+                    </div>
+                  );
+                })}
+                {availableFolders.length === 1 && (
+                  <div className="rounded-2xl border border-dashed border-white/10 p-4 text-sm text-slate-400">
+                    No Telegram folders found yet. Use Storage as admin to sync or create folders, then refresh this list.
+                  </div>
+                )}
+              </div>
+
+              <button onClick={savePermissions} className="mt-3 rounded-2xl bg-cyan-400 px-4 py-3 font-medium text-slate-950 transition hover:bg-cyan-300">
+                Save Permissions
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SessionsPanel({ csrfToken }: { csrfToken: string | null }) {
+  const client = useQueryClient();
+  const sessions = useQuery({ queryKey: ["admin-sessions"], queryFn: nasApi.listSessions, retry: false });
+
+  const revoke = async (sessionId: string) => {
+    if (!csrfToken) return;
+    await nasApi.revokeSession(sessionId, csrfToken);
+    client.invalidateQueries({ queryKey: ["admin-sessions"] });
+    toast.success("Session revoked");
+  };
+
+  return (
+    <div className="rounded-[32px] border border-white/10 bg-black/25 p-6">
+      <p className="text-xs uppercase tracking-[0.32em] text-cyan-300">Active Sessions</p>
+      <div className="mt-4 grid gap-3">
+        {sessions.data?.map((session: AppSession) => (
+          <div key={session.id} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p className="font-medium">{session.username}</p>
+                <p className="text-sm text-slate-300">{session.ip_address}</p>
+                <p className="mt-1 text-xs text-slate-400">{session.user_agent}</p>
+              </div>
+              <button onClick={() => revoke(session.id)} className="rounded-2xl border border-white/10 px-4 py-2 text-sm transition hover:bg-white/8">
+                Revoke
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function AuditPanel() {
+  const audit = useQuery({ queryKey: ["admin-audit"], queryFn: nasApi.listAuditLogs, retry: false });
+  return (
+    <div className="rounded-[32px] border border-white/10 bg-black/25 p-6">
+      <p className="text-xs uppercase tracking-[0.32em] text-cyan-300">Audit Trail</p>
+      <div className="mt-4 space-y-3">
+        {audit.data?.map((entry: AuditEntry) => (
+          <div key={entry.id} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+            <p className="font-medium">{entry.action}</p>
+            <p className="text-sm text-slate-300">{entry.target_type} · {entry.target_id}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function UserHome({ me, onLogout }: { me: MeResponse; onLogout: () => void }) {
+  return (
+    <Dashboard
+      onLogout={onLogout}
+      permissions={me.permissions}
+      allowFolderManagement={false}
+    />
+  );
+}
+
+function Feature({
+  icon: Icon,
+  title,
+  copy,
+}: {
+  icon: typeof Shield;
+  title: string;
+  copy: string;
+}) {
+  return (
+    <div className="rounded-[28px] border border-white/10 bg-black/20 p-5">
+      <div className="mb-3 inline-flex rounded-full border border-cyan-400/20 bg-cyan-400/10 p-3 text-cyan-300">
+        <Icon className="h-5 w-5" />
+      </div>
+      <h3 className="text-lg font-medium">{title}</h3>
+      <p className="mt-2 text-sm leading-6 text-slate-300">{copy}</p>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+  type = "text",
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  type?: string;
+}) {
+  return (
+    <label className="block text-sm">
+      <span className="mb-2 block text-slate-300">{label}</span>
+      <input
+        type={type}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 outline-none transition focus:border-cyan-300/60"
+      />
+    </label>
+  );
+}
 
 function App() {
   return (

--- a/app/src/components/Dashboard.tsx
+++ b/app/src/components/Dashboard.tsx
@@ -1,10 +1,12 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { AnimatePresence } from 'framer-motion';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { invoke } from '@tauri-apps/api/core';
 import { toast } from 'sonner';
+import { LogOut, Shield } from 'lucide-react';
 
-import { TelegramFile, BandwidthStats } from '../types';
+import { TelegramFile, BandwidthStats, TelegramFolder } from '../types';
+import type { PermissionAssignment } from '../types/nas';
 import { formatBytes, isMediaFile, isPdfFile } from '../utils';
 
 // Components
@@ -27,14 +29,60 @@ import { useFileUpload } from '../hooks/useFileUpload';
 import { useFileDownload } from '../hooks/useFileDownload';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 
-export function Dashboard({ onLogout }: { onLogout: () => void }) {
+interface DashboardProps {
+    onLogout: () => void;
+    permissions?: PermissionAssignment[];
+    allowFolderManagement?: boolean;
+    adminControls?: {
+        onAdminBack: () => void;
+    };
+}
+
+const isRootPermission = (folderId: string) => {
+    const normalized = folderId.trim().toLowerCase();
+    return normalized === "me" || normalized === "home" || normalized === "saved_messages" || normalized === "saved messages" || normalized === "null" || normalized === "root";
+};
+
+export function Dashboard({ onLogout, permissions, allowFolderManagement = true, adminControls }: DashboardProps) {
     const queryClient = useQueryClient();
 
 
     const {
         store, folders, activeFolderId, setActiveFolderId, isSyncing, isConnected,
-        handleLogout, handleSyncFolders, handleCreateFolder, handleFolderDelete
+        handleSyncFolders, handleCreateFolder, handleFolderDelete
     } = useTelegramConnection(onLogout);
+
+    const isPermissionMode = !!permissions;
+    const permissionByFolder = useMemo(
+        () => new Map(
+            permissions?.map((permission) => [
+                isRootPermission(permission.folder_id) ? "root" : permission.folder_id,
+                permission,
+            ]) || []
+        ),
+        [permissions]
+    );
+    const showSavedMessages = !isPermissionMode || permissionByFolder.has("root");
+    const visibleFolders: TelegramFolder[] = useMemo(
+        () => isPermissionMode
+            ? permissions
+                .filter((permission) => !isRootPermission(permission.folder_id))
+                .map((permission) => ({
+                    id: Number(permission.folder_id),
+                    name: permission.folder_label,
+                }))
+                .filter((folder) => Number.isFinite(folder.id))
+            : folders,
+        [folders, isPermissionMode, permissions]
+    );
+    const activePermission = isPermissionMode
+        ? permissionByFolder.get(activeFolderId === null ? "root" : String(activeFolderId))
+        : undefined;
+    const canWrite = !isPermissionMode || activePermission?.access_level === "read_write";
+    const hasFolderAccess = !isPermissionMode || showSavedMessages || visibleFolders.length > 0;
+    const activeFolderAllowed = !isPermissionMode || (activeFolderId === null
+        ? showSavedMessages
+        : visibleFolders.some((folder) => folder.id === activeFolderId));
 
 
     const [previewFile, setPreviewFile] = useState<TelegramFile | null>(null);
@@ -70,6 +118,22 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
         }
     }, [store, viewMode]);
 
+    useEffect(() => {
+        if (!isPermissionMode) return;
+
+        const activeAllowed = activeFolderId === null
+            ? showSavedMessages
+            : visibleFolders.some((folder) => folder.id === activeFolderId);
+
+        if (activeAllowed) return;
+
+        if (showSavedMessages) {
+            setActiveFolderId(null);
+        } else if (visibleFolders[0]) {
+            setActiveFolderId(visibleFolders[0].id);
+        }
+    }, [isPermissionMode, activeFolderId, showSavedMessages, visibleFolders, setActiveFolderId]);
+
 
     const { data: allFiles = [], isLoading, error } = useQuery({
         queryKey: ['files', activeFolderId],
@@ -78,7 +142,7 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
             sizeStr: formatBytes(f.size),
             type: f.icon_type || (f.name.endsWith('/') ? 'folder' : 'file')
         }))),
-        enabled: !!store,
+        enabled: !!store && hasFolderAccess && activeFolderAllowed,
     });
 
     const displayedFiles = searchTerm.length > 2
@@ -108,10 +172,11 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
     }, [displayedFiles]);
 
     const handleKeyboardDelete = useCallback(() => {
+        if (!canWrite) return;
         if (selectedIds.length > 0) {
             handleBulkDelete();
         }
-    }, [selectedIds, handleBulkDelete]);
+    }, [selectedIds, handleBulkDelete, canWrite]);
 
     const handleEscape = useCallback(() => {
         setSelectedIds([]);
@@ -291,6 +356,11 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
         e.preventDefault();
         e.stopPropagation();
 
+        if (!canWrite) {
+            toast.error("This folder is read-only.");
+            return;
+        }
+
         const dataTransferFileId = e.dataTransfer.getData("application/x-telegram-file-id");
 
         if (activeFolderId === targetFolderId) return;
@@ -320,13 +390,15 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
         }
     }
 
-    const currentFolderName = activeFolderId === null
+    const currentFolderName = !hasFolderAccess
+        ? "No folder assigned"
+        : activeFolderId === null
         ? "Saved Messages"
-        : folders.find(f => f.id === activeFolderId)?.name || "Folder";
+        : visibleFolders.find(f => f.id === activeFolderId)?.name || folders.find(f => f.id === activeFolderId)?.name || "Folder";
 
 
     const handleRootDragOver = (e: React.DragEvent) => {
-        if (internalDragRef.current) {
+        if (canWrite && internalDragRef.current) {
             e.preventDefault();
             e.stopPropagation();
             e.dataTransfer.dropEffect = 'move';
@@ -334,7 +406,7 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
     };
 
     const handleRootDragEnter = (e: React.DragEvent) => {
-        if (internalDragRef.current) {
+        if (canWrite && internalDragRef.current) {
             e.preventDefault();
             e.stopPropagation();
             e.dataTransfer.dropEffect = 'move';
@@ -351,12 +423,12 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
             onDragEnter={handleRootDragEnter}
         >
 
-            <ExternalDropBlocker onUploadClick={handleManualUpload} />
+            {canWrite && <ExternalDropBlocker onUploadClick={handleManualUpload} />}
 
             <AnimatePresence>
                 {showMoveModal && (
                     <MoveToFolderModal
-                        folders={folders}
+                        folders={visibleFolders}
                         onClose={() => setShowMoveModal(false)}
                         onSelect={handleBulkMove}
                         activeFolderId={activeFolderId}
@@ -387,11 +459,11 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
                         key="pdf-viewer"
                     />
                 )}
-                {isDragging && internalDragFileId === null && <DragDropOverlay key="drag-drop-overlay" />}
+                {canWrite && isDragging && internalDragFileId === null && <DragDropOverlay key="drag-drop-overlay" />}
             </AnimatePresence>
 
             <Sidebar
-                folders={folders}
+                folders={visibleFolders}
                 activeFolderId={activeFolderId}
                 setActiveFolderId={setActiveFolderId}
                 onDrop={handleDropOnFolder}
@@ -400,8 +472,10 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
                 isSyncing={isSyncing}
                 isConnected={isConnected}
                 onSync={handleSyncFolders}
-                onLogout={handleLogout}
+                onLogout={onLogout}
                 bandwidth={bandwidth || null}
+                allowFolderManagement={allowFolderManagement}
+                showSavedMessages={showSavedMessages}
             />
 
             <main className="flex-1 flex flex-col" onClick={(e) => { if (e.target === e.currentTarget) setSelectedIds([]); }}>
@@ -416,6 +490,32 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
                     setViewMode={setViewMode}
                     searchTerm={searchTerm}
                     onSearchChange={setSearchTerm}
+                    canWrite={canWrite}
+                    extraActions={adminControls && (
+                        <>
+                            <div className="w-px h-6 bg-telegram-border mx-1"></div>
+                            <button
+                                onClick={adminControls.onAdminBack}
+                                className="p-2 hover:bg-telegram-hover rounded-md text-telegram-subtext hover:text-telegram-text transition relative group"
+                                title="Admin Console"
+                            >
+                                <Shield className="w-5 h-5" />
+                                <span className="absolute -bottom-8 left-1/2 -translate-x-1/2 text-[10px] bg-telegram-surface border border-telegram-border px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-lg">
+                                    Admin
+                                </span>
+                            </button>
+                            <button
+                                onClick={onLogout}
+                                className="p-2 hover:bg-telegram-hover rounded-md text-telegram-subtext hover:text-red-400 transition relative group"
+                                title="Sign Out"
+                            >
+                                <LogOut className="w-5 h-5" />
+                                <span className="absolute -bottom-8 left-1/2 -translate-x-1/2 text-[10px] bg-telegram-surface border border-telegram-border px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-lg">
+                                    Sign Out
+                                </span>
+                            </button>
+                        </>
+                    )}
                 />
                 {searchTerm.length > 2 && (
                     <div className="px-6 pt-4 pb-0">
@@ -442,6 +542,7 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
                     onDrop={handleDropOnFolder}
                     onDragStart={(fileId) => setInternalDragFileId(fileId)}
                     onDragEnd={() => setTimeout(() => setInternalDragFileId(null), 50)}
+                    canWrite={canWrite}
                 />
             </main>
 

--- a/app/src/components/dashboard/ContextMenu.tsx
+++ b/app/src/components/dashboard/ContextMenu.tsx
@@ -11,9 +11,10 @@ interface ContextMenuProps {
     onDownload: () => void;
     onDelete: () => void;
     onPreview: () => void;
+    canWrite?: boolean;
 }
 
-export function ContextMenu({ x, y, file, onClose, onDownload, onDelete, onPreview }: ContextMenuProps) {
+export function ContextMenu({ x, y, file, onClose, onDownload, onDelete, onPreview, canWrite = true }: ContextMenuProps) {
     const [adjustedPos, setAdjustedPos] = useState({ x, y });
     const menuRef = useRef<HTMLDivElement>(null);
 
@@ -95,17 +96,21 @@ export function ContextMenu({ x, y, file, onClose, onDownload, onDelete, onPrevi
                 Download
             </button>
 
-            <button disabled className="flex items-center gap-2 px-2 py-1.5 text-sm text-telegram-subtext hover:bg-telegram-hover rounded transition-colors text-left w-full cursor-not-allowed opacity-50">
-                <Pencil className="w-4 h-4" />
-                Rename
-            </button>
+            {canWrite && (
+                <button disabled className="flex items-center gap-2 px-2 py-1.5 text-sm text-telegram-subtext hover:bg-telegram-hover rounded transition-colors text-left w-full cursor-not-allowed opacity-50">
+                    <Pencil className="w-4 h-4" />
+                    Rename
+                </button>
+            )}
 
-            <div className="h-px bg-telegram-border my-1" />
+            {canWrite && <div className="h-px bg-telegram-border my-1" />}
 
-            <button onClick={onDelete} className="flex items-center gap-2 px-2 py-1.5 text-sm text-red-500 hover:bg-red-500/10 rounded transition-colors text-left w-full">
-                <Trash2 className="w-4 h-4" />
-                Delete
-            </button>
+            {canWrite && (
+                <button onClick={onDelete} className="flex items-center gap-2 px-2 py-1.5 text-sm text-red-500 hover:bg-red-500/10 rounded transition-colors text-left w-full">
+                    <Trash2 className="w-4 h-4" />
+                    Delete
+                </button>
+            )}
         </div>
     );
 }

--- a/app/src/components/dashboard/EmptyState.tsx
+++ b/app/src/components/dashboard/EmptyState.tsx
@@ -1,7 +1,7 @@
 import { Upload } from 'lucide-react';
 
 interface EmptyStateProps {
-    onUpload: () => void;
+    onUpload?: () => void;
 }
 
 export function EmptyState({ onUpload }: EmptyStateProps) {
@@ -52,16 +52,18 @@ export function EmptyState({ onUpload }: EmptyStateProps) {
                 This folder is empty
             </h3>
             <p className="text-telegram-subtext text-sm mb-6 max-w-xs">
-                Drag and drop files here, or click the button below to upload from your computer.
+                {onUpload ? "Drag and drop files here, or click the button below to upload from your computer." : "This folder is available to view, but uploads are disabled for your account."}
             </p>
 
-            <button
-                onClick={onUpload}
-                className="inline-flex items-center gap-2 px-6 py-3 bg-telegram-primary text-black font-medium rounded-xl hover:bg-telegram-primary/90 transition-all hover:scale-105 shadow-lg shadow-telegram-primary/20"
-            >
-                <Upload className="w-5 h-5" />
-                Upload Files
-            </button>
+            {onUpload && (
+                <button
+                    onClick={onUpload}
+                    className="inline-flex items-center gap-2 px-6 py-3 bg-telegram-primary text-black font-medium rounded-xl hover:bg-telegram-primary/90 transition-all hover:scale-105 shadow-lg shadow-telegram-primary/20"
+                >
+                    <Upload className="w-5 h-5" />
+                    Upload Files
+                </button>
+            )}
 
             <p className="text-xs text-telegram-subtext/50 mt-6">
                 Tip: Use <kbd className="px-1.5 py-0.5 bg-telegram-hover rounded text-telegram-subtext">Cmd + F</kbd> to search

--- a/app/src/components/dashboard/FileCard.tsx
+++ b/app/src/components/dashboard/FileCard.tsx
@@ -19,6 +19,7 @@ interface FileCardProps {
     activeFolderId?: number | null;
     height?: number;
     onToggleSelection?: () => void;
+    canWrite?: boolean;
 }
 
 // Check if file is an image type that can have a thumbnail
@@ -27,7 +28,7 @@ function isImageFile(filename: string): boolean {
     return ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp'].includes(ext);
 }
 
-export function FileCard({ file, onDelete, onDownload, onPreview, isSelected, onClick, onContextMenu, onDrop, onDragStart, onDragEnd, activeFolderId, height, onToggleSelection }: FileCardProps) {
+export function FileCard({ file, onDelete, onDownload, onPreview, isSelected, onClick, onContextMenu, onDrop, onDragStart, onDragEnd, activeFolderId, height, onToggleSelection, canWrite = true }: FileCardProps) {
     const isFolder = file.type === 'folder';
     const [isDragOver, setIsDragOver] = useState(false);
     const [thumbnail, setThumbnail] = useState<string | null>(null);
@@ -86,8 +87,9 @@ export function FileCard({ file, onDelete, onDownload, onPreview, isSelected, on
         >
             <motion.div
                 layout
-                draggable={!isFolder}
+                draggable={!isFolder && canWrite}
                 onDragStart={(e: any) => {
+                    if (!canWrite) return;
                     if (onDragStart) onDragStart(file.id);
                     e.dataTransfer.setData("application/x-telegram-file-id", file.id.toString());
                     e.dataTransfer.effectAllowed = 'move';
@@ -149,9 +151,11 @@ export function FileCard({ file, onDelete, onDownload, onPreview, isSelected, on
                     <button onClick={(e) => { e.stopPropagation(); onDownload() }} className="file-action-btn p-1 bg-black/50 rounded-full hover:bg-green-500 hover:text-white text-white/70" title="Download">
                         <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-3 h-3"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
                     </button>
-                    <button onClick={(e) => { e.stopPropagation(); onDelete() }} className="file-action-btn p-1 bg-black/50 rounded-full hover:bg-red-500 hover:text-white text-white/70" title="Delete">
-                        <Trash2 className="w-3 h-3" />
-                    </button>
+                    {canWrite && (
+                        <button onClick={(e) => { e.stopPropagation(); onDelete() }} className="file-action-btn p-1 bg-black/50 rounded-full hover:bg-red-500 hover:text-white text-white/70" title="Delete">
+                            <Trash2 className="w-3 h-3" />
+                        </button>
+                    )}
                 </div>
             </motion.div>
         </div>

--- a/app/src/components/dashboard/FileExplorer.tsx
+++ b/app/src/components/dashboard/FileExplorer.tsx
@@ -27,6 +27,7 @@ interface FileExplorerProps {
     onDrop?: (e: React.DragEvent, folderId: number) => void;
     onDragStart?: (fileId: number) => void;
     onDragEnd?: () => void;
+    canWrite?: boolean;
 }
 
 
@@ -58,7 +59,8 @@ function useGridColumns(containerRef: React.RefObject<HTMLDivElement | null>) {
 
 export function FileExplorer({
     files, loading, error, viewMode, selectedIds, activeFolderId,
-    onFileClick, onDelete, onDownload, onPreview, onManualUpload, onSelectionClear, onToggleSelection, onDrop, onDragStart, onDragEnd
+    onFileClick, onDelete, onDownload, onPreview, onManualUpload, onSelectionClear, onToggleSelection, onDrop, onDragStart, onDragEnd,
+    canWrite = true
 }: FileExplorerProps) {
     const [sortField, setSortField] = useState<SortField>('name');
     const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
@@ -103,17 +105,17 @@ export function FileExplorer({
 
     const gridRows = useMemo(() => {
         const rows: (TelegramFile | 'upload')[][] = [];
-        const itemsWithUpload: (TelegramFile | 'upload')[] = [...sortedFiles, 'upload'];
+        const itemsWithUpload: (TelegramFile | 'upload')[] = canWrite ? [...sortedFiles, 'upload'] : [...sortedFiles];
         for (let i = 0; i < itemsWithUpload.length; i += columns) {
             rows.push(itemsWithUpload.slice(i, i + columns));
         }
         return rows;
-    }, [sortedFiles, columns]);
+    }, [sortedFiles, columns, canWrite]);
 
 
     const listItems = useMemo(() => {
-        return activeFolderId === null ? [...sortedFiles, 'upload' as const] : sortedFiles;
-    }, [sortedFiles, activeFolderId]);
+        return activeFolderId === null && canWrite ? [...sortedFiles, 'upload' as const] : sortedFiles;
+    }, [sortedFiles, activeFolderId, canWrite]);
 
 
     const gridVirtualizer = useVirtualizer({
@@ -168,7 +170,7 @@ export function FileExplorer({
     if (files.length === 0) {
         return (
             <div className="flex-1 p-6 overflow-auto">
-                <EmptyState onUpload={onManualUpload} />
+                <EmptyState onUpload={canWrite ? onManualUpload : undefined} />
             </div>
         );
     }
@@ -255,6 +257,7 @@ export function FileExplorer({
                                                 activeFolderId={activeFolderId}
                                                 height={cardHeight}
                                                 onToggleSelection={() => onToggleSelection(file.id)}
+                                                canWrite={canWrite}
                                             />
                                         );
                                     })}
@@ -321,6 +324,7 @@ export function FileExplorer({
                                         onPreview={handlePreviewRequest}
                                         onDownload={onDownload}
                                         onDelete={onDelete}
+                                        canWrite={canWrite}
                                     />
                                 </div>
                             );
@@ -340,7 +344,7 @@ export function FileExplorer({
                         setContextMenu(null);
                     }}
                     onDelete={() => {
-                        onDelete(contextMenu.file.id);
+                        if (canWrite) onDelete(contextMenu.file.id);
                         setContextMenu(null);
                     }}
                     onPreview={() => {
@@ -351,6 +355,7 @@ export function FileExplorer({
                         }
                         setContextMenu(null);
                     }}
+                    canWrite={canWrite}
                 />
             )}
         </div>

--- a/app/src/components/dashboard/FileExplorer.tsx
+++ b/app/src/components/dashboard/FileExplorer.tsx
@@ -56,6 +56,8 @@ function useGridColumns(containerRef: React.RefObject<HTMLDivElement | null>) {
     return { columns, containerWidth };
 }
 
+const isTextMessagesFile = (file: TelegramFile) => file.id === -1 && file.name === 'Text messages.txt';
+
 export function FileExplorer({
     files, loading, error, viewMode, selectedIds, activeFolderId,
     onFileClick, onDelete, onDownload, onPreview, onManualUpload, onSelectionClear, onToggleSelection, onDrop, onDragStart, onDragEnd
@@ -80,6 +82,12 @@ export function FileExplorer({
 
     const sortedFiles = useMemo(() => {
         return [...files].sort((a, b) => {
+            const aIsTextMessages = isTextMessagesFile(a);
+            const bIsTextMessages = isTextMessagesFile(b);
+            if (aIsTextMessages || bIsTextMessages) {
+                return aIsTextMessages ? -1 : 1;
+            }
+
             let comparison = 0;
             switch (sortField) {
                 case 'name':

--- a/app/src/components/dashboard/FileListItem.tsx
+++ b/app/src/components/dashboard/FileListItem.tsx
@@ -14,12 +14,14 @@ interface FileListItemProps {
     onPreview: (file: TelegramFile) => void;
     onDownload: (id: number, name: string) => void;
     onDelete: (id: number) => void;
+    canWrite?: boolean;
 }
 
 export function FileListItem({
     file, selectedIds, onFileClick, handleContextMenu,
     onDragStart, onDragEnd, onDrop,
-    onPreview, onDownload, onDelete
+    onPreview, onDownload, onDelete,
+    canWrite = true
 }: FileListItemProps) {
     const [isDragOver, setIsDragOver] = useState(false);
     const isFolder = file.type === 'folder';
@@ -28,8 +30,9 @@ export function FileListItem({
         <div
             onClick={(e) => onFileClick(e, file.id)}
             onContextMenu={(e) => handleContextMenu(e, file)}
-            draggable
+            draggable={canWrite}
             onDragStart={(e) => {
+                if (!canWrite) return;
                 if (onDragStart) onDragStart(file.id);
                 e.dataTransfer.setData("application/x-telegram-file-id", file.id.toString());
                 e.dataTransfer.effectAllowed = 'move';
@@ -73,7 +76,7 @@ export function FileListItem({
                 <div className="absolute right-0 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 flex items-center bg-telegram-surface border border-telegram-border shadow-lg rounded px-1">
                     <button onClick={(e) => { e.stopPropagation(); onPreview(file) }} className="p-1 hover:text-telegram-text text-telegram-subtext" title="Preview"><Eye className="w-4 h-4" /></button>
                     <button onClick={(e) => { e.stopPropagation(); onDownload(file.id, file.name) }} className="p-1 hover:text-telegram-text text-telegram-subtext" title="Download"><HardDrive className="w-4 h-4" /></button>
-                    <button onClick={(e) => { e.stopPropagation(); onDelete(file.id) }} className="p-1 hover:text-red-400 text-telegram-subtext" title="Delete"><Plus className="w-4 h-4 rotate-45" /></button>
+                    {canWrite && <button onClick={(e) => { e.stopPropagation(); onDelete(file.id) }} className="p-1 hover:text-red-400 text-telegram-subtext" title="Delete"><Plus className="w-4 h-4 rotate-45" /></button>}
                 </div>
             </div>
             <div className="text-right text-xs text-telegram-subtext truncate">{file.sizeStr}</div>

--- a/app/src/components/dashboard/PreviewModal.tsx
+++ b/app/src/components/dashboard/PreviewModal.tsx
@@ -3,7 +3,7 @@ import { X, File, ChevronLeft, ChevronRight } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { TelegramFile } from '../../types';
-import { isImageFile } from '../../utils';
+import { isImageFile, isTextFile } from '../../utils';
 
 const PREVIEW_CACHE_TTL_MS = 5 * 60 * 1000;
 const PREVIEW_CACHE_MAX_ITEMS = 8;
@@ -51,6 +51,18 @@ const forgetPreview = (key: string) => {
 };
 
 const isSafeToPrefetch = (name: string) => isImageFile(name);
+
+const decodeTextDataUrl = (src: string) => {
+    const prefix = 'data:text/plain;base64,';
+    if (!src.startsWith(prefix)) return null;
+    try {
+        const binary = atob(src.slice(prefix.length));
+        const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+        return new TextDecoder().decode(bytes);
+    } catch {
+        return null;
+    }
+};
 
 interface PreviewModalProps {
     file: TelegramFile;
@@ -242,6 +254,12 @@ export function PreviewModal({ file, onClose, onNext, onPrev, currentIndex, tota
                                     setError('Failed to render image preview');
                                 }}
                             />
+                        ) : isTextFile(file.name) ? (
+                            <div className="bg-[#141c26] border border-white/10 shadow-2xl rounded-lg max-w-4xl max-h-[80vh] overflow-auto p-5">
+                                <pre className="text-left text-sm leading-6 text-white/90 whitespace-pre-wrap break-words font-mono">
+                                    {file.text_content || decodeTextDataUrl(src) || ''}
+                                </pre>
+                            </div>
                         ) : (
                             <div className="bg-[#1c1c1c] p-8 rounded-xl text-center border border-white/10 shadow-2xl">
                                 <File className="w-16 h-16 text-telegram-primary mx-auto mb-4" />

--- a/app/src/components/dashboard/PreviewModal.tsx
+++ b/app/src/components/dashboard/PreviewModal.tsx
@@ -64,6 +64,30 @@ const decodeTextDataUrl = (src: string) => {
     }
 };
 
+type TextMessageBlock = {
+    id: string;
+    date: string;
+    body: string;
+};
+
+const parseTextMessageBlocks = (text: string): TextMessageBlock[] => {
+    const pattern = /^={20,}\nMESSAGE #(.+)\nDATE: (.+)\n={20,}\n/gm;
+    const matches = [...text.matchAll(pattern)];
+    if (matches.length === 0) return [];
+
+    return matches.map((match, index) => {
+        const bodyStart = (match.index ?? 0) + match[0].length;
+        const nextMatch = matches[index + 1];
+        const bodyEnd = nextMatch?.index ?? text.length;
+
+        return {
+            id: match[1],
+            date: match[2],
+            body: text.slice(bodyStart, bodyEnd).trim(),
+        };
+    });
+};
+
 interface PreviewModalProps {
     file: TelegramFile;
     onClose: () => void;
@@ -91,6 +115,13 @@ export function PreviewModal({ file, onClose, onNext, onPrev, currentIndex, tota
 
     useEffect(() => {
         const load = async () => {
+            if (file.text_content && isTextFile(file.name)) {
+                setSrc('data:text/plain;base64,');
+                setLoading(false);
+                setError(null);
+                return;
+            }
+
             const key = getPreviewCacheKey(file.id, activeFolderId);
             const shouldBypassCache = reloadNonce > 0;
             const requestId = ++latestRequestRef.current;
@@ -256,9 +287,34 @@ export function PreviewModal({ file, onClose, onNext, onPrev, currentIndex, tota
                             />
                         ) : isTextFile(file.name) ? (
                             <div className="bg-[#141c26] border border-white/10 shadow-2xl rounded-lg max-w-4xl max-h-[80vh] overflow-auto p-5">
-                                <pre className="text-left text-sm leading-6 text-white/90 whitespace-pre-wrap break-words font-mono">
-                                    {file.text_content || decodeTextDataUrl(src) || ''}
-                                </pre>
+                                {(() => {
+                                    const text = file.text_content || decodeTextDataUrl(src) || '';
+                                    const blocks = parseTextMessageBlocks(text);
+
+                                    if (blocks.length === 0) {
+                                        return (
+                                            <pre className="text-left text-sm leading-6 text-white/90 whitespace-pre-wrap break-words font-mono">
+                                                {text}
+                                            </pre>
+                                        );
+                                    }
+
+                                    return (
+                                        <div className="space-y-8 text-left font-mono">
+                                            {blocks.map((block) => (
+                                                <section key={`${block.id}-${block.date}`} className="border-t border-white/20 pt-4">
+                                                    <div className="mb-4">
+                                                        <div className="text-xl font-bold text-white">Message #{block.id}</div>
+                                                        <div className="mt-1 text-sm font-semibold text-telegram-primary">{block.date}</div>
+                                                    </div>
+                                                    <pre className="text-sm leading-6 text-white/90 whitespace-pre-wrap break-words font-mono">
+                                                        {block.body}
+                                                    </pre>
+                                                </section>
+                                            ))}
+                                        </div>
+                                    );
+                                })()}
                             </div>
                         ) : (
                             <div className="bg-[#1c1c1c] p-8 rounded-xl text-center border border-white/10 shadow-2xl">

--- a/app/src/components/dashboard/Sidebar.tsx
+++ b/app/src/components/dashboard/Sidebar.tsx
@@ -16,11 +16,15 @@ interface SidebarProps {
     onSync: () => void;
     onLogout: () => void;
     bandwidth: BandwidthStats | null;
+    allowFolderManagement?: boolean;
+    showSavedMessages?: boolean;
 }
 
 export function Sidebar({
     folders, activeFolderId, setActiveFolderId, onDrop, onDelete, onCreate,
-    isSyncing, isConnected, onSync, onLogout, bandwidth
+    isSyncing, isConnected, onSync, onLogout, bandwidth,
+    allowFolderManagement = true,
+    showSavedMessages = true
 }: SidebarProps) {
     const [showNewFolderInput, setShowNewFolderInput] = useState(false);
     const [newFolderName, setNewFolderName] = useState("");
@@ -45,14 +49,16 @@ export function Sidebar({
 
             {/* Scrollable folder list */}
             <nav className="flex-1 px-2 py-4 space-y-1 overflow-y-auto min-h-0">
-                <SidebarItem
-                    icon={HardDrive}
-                    label="Saved Messages"
-                    active={activeFolderId === null}
-                    onClick={() => setActiveFolderId(null)}
-                    onDrop={(e: React.DragEvent) => onDrop(e, null)}
-                    folderId={null}
-                />
+                {showSavedMessages && (
+                    <SidebarItem
+                        icon={HardDrive}
+                        label="Saved Messages"
+                        active={activeFolderId === null}
+                        onClick={() => setActiveFolderId(null)}
+                        onDrop={(e: React.DragEvent) => onDrop(e, null)}
+                        folderId={null}
+                    />
+                )}
                 {folders.map(folder => (
                     <SidebarItem
                         key={folder.id}
@@ -61,13 +67,14 @@ export function Sidebar({
                         active={activeFolderId === folder.id}
                         onClick={() => setActiveFolderId(folder.id)}
                         onDrop={(e: React.DragEvent) => onDrop(e, folder.id)}
-                        onDelete={() => onDelete(folder.id, folder.name)}
+                        onDelete={allowFolderManagement ? () => onDelete(folder.id, folder.name) : undefined}
                         folderId={folder.id}
                     />
                 ))}
             </nav>
 
             {/* Sticky Create Folder section — always visible above the footer */}
+            {allowFolderManagement && (
             <div className="px-2 pb-2 border-b border-telegram-border">
                 {showNewFolderInput ? (
                     <div className="px-3 py-2">
@@ -92,6 +99,7 @@ export function Sidebar({
                     </button>
                 )}
             </div>
+            )}
 
             <div className="p-4 border-t border-telegram-border">
                 <div className="flex items-center gap-2 text-telegram-subtext text-xs">
@@ -100,15 +108,17 @@ export function Sidebar({
                 </div>
 
                 <div className="flex gap-2 mt-4">
-                    <button
-                        onClick={onSync}
-                        disabled={isSyncing}
-                        className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 text-xs font-medium text-blue-500 hover:text-blue-600 bg-blue-500/10 hover:bg-blue-500/20 rounded-lg transition-colors ${isSyncing ? 'opacity-50 cursor-not-allowed' : ''}`}
-                        title="Scan for existing folders"
-                    >
-                        <RefreshCw className={`w-3 h-3 ${isSyncing ? 'animate-spin' : ''}`} />
-                        {isSyncing ? 'Syncing...' : 'Sync'}
-                    </button>
+                    {allowFolderManagement && (
+                        <button
+                            onClick={onSync}
+                            disabled={isSyncing}
+                            className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 text-xs font-medium text-blue-500 hover:text-blue-600 bg-blue-500/10 hover:bg-blue-500/20 rounded-lg transition-colors ${isSyncing ? 'opacity-50 cursor-not-allowed' : ''}`}
+                            title="Scan for existing folders"
+                        >
+                            <RefreshCw className={`w-3 h-3 ${isSyncing ? 'animate-spin' : ''}`} />
+                            {isSyncing ? 'Syncing...' : 'Sync'}
+                        </button>
+                    )}
                     <button
                         onClick={onLogout}
                         className="flex-1 flex items-center justify-center gap-2 px-3 py-2 text-xs font-medium text-red-500 hover:text-red-600 bg-red-500/10 hover:bg-red-500/20 rounded-lg transition-colors"

--- a/app/src/components/dashboard/TopBar.tsx
+++ b/app/src/components/dashboard/TopBar.tsx
@@ -1,4 +1,5 @@
 import { HardDrive, LayoutGrid, Sun, Moon } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { useTheme } from '../../context/ThemeContext';
 
 interface TopBarProps {
@@ -12,11 +13,15 @@ interface TopBarProps {
     setViewMode: (mode: 'grid' | 'list') => void;
     searchTerm: string;
     onSearchChange: (term: string) => void;
+    canWrite?: boolean;
+    extraActions?: ReactNode;
 }
 
 export function TopBar({
     currentFolderName, selectedIds, onShowMoveModal, onBulkDownload, onBulkDelete,
-    onDownloadFolder, viewMode, setViewMode, searchTerm, onSearchChange
+    onDownloadFolder, viewMode, setViewMode, searchTerm, onSearchChange,
+    canWrite = true,
+    extraActions
 }: TopBarProps) {
     const { theme, toggleTheme } = useTheme();
 
@@ -44,9 +49,9 @@ export function TopBar({
                 {selectedIds.length > 0 && (
                     <div className="flex items-center gap-2 mr-4 animate-in fade-in slide-in-from-top-2">
                         <span className="text-xs text-telegram-subtext mr-2">{selectedIds.length} Selected</span>
-                        <button onClick={onShowMoveModal} className="px-3 py-1.5 bg-telegram-primary/20 hover:bg-telegram-primary/30 text-telegram-primary rounded-md text-xs transition font-medium">Move to...</button>
+                        {canWrite && <button onClick={onShowMoveModal} className="px-3 py-1.5 bg-telegram-primary/20 hover:bg-telegram-primary/30 text-telegram-primary rounded-md text-xs transition font-medium">Move to...</button>}
                         <button onClick={onBulkDownload} className="px-3 py-1.5 bg-telegram-hover hover:bg-telegram-border rounded-md text-xs text-telegram-text transition">Download Selected</button>
-                        <button onClick={onBulkDelete} className="px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-400 rounded-md text-xs transition">Delete</button>
+                        {canWrite && <button onClick={onBulkDelete} className="px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-400 rounded-md text-xs transition">Delete</button>}
                     </div>
                 )}
 
@@ -80,6 +85,8 @@ export function TopBar({
                         {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
                     </span>
                 </button>
+
+                {extraActions}
             </div>
         </header>
     )

--- a/app/src/hooks/useFileOperations.ts
+++ b/app/src/hooks/useFileOperations.ts
@@ -4,6 +4,8 @@ import { toast } from 'sonner';
 import { useConfirm } from '../context/ConfirmContext';
 import { TelegramFile } from '../types';
 
+const TEXT_MESSAGES_FILE_ID = -1;
+
 export function useFileOperations(
     activeFolderId: number | null,
     selectedIds: number[],
@@ -12,8 +14,13 @@ export function useFileOperations(
 ) {
     const queryClient = useQueryClient();
     const { confirm } = useConfirm();
+    const isTextMessagesFile = (id: number) => id === TEXT_MESSAGES_FILE_ID;
 
     const handleDelete = async (id: number) => {
+        if (isTextMessagesFile(id)) {
+            toast.info("Text messages are grouped for display and cannot be deleted as a single file.");
+            return;
+        }
         if (!await confirm({ title: "Delete File", message: "Are you sure you want to delete this file?", confirmText: "Delete", variant: 'danger' })) return;
         try {
             await invoke('cmd_delete_file', { messageId: id, folderId: activeFolderId });
@@ -26,11 +33,16 @@ export function useFileOperations(
 
     const handleBulkDelete = async () => {
         if (selectedIds.length === 0) return;
-        if (!await confirm({ title: "Delete Files", message: `Are you sure you want to delete ${selectedIds.length} files?`, confirmText: "Delete All", variant: 'danger' })) return;
+        const deletableIds = selectedIds.filter((id) => !isTextMessagesFile(id));
+        if (deletableIds.length === 0) {
+            toast.info("Text messages are grouped for display and cannot be deleted as a single file.");
+            return;
+        }
+        if (!await confirm({ title: "Delete Files", message: `Are you sure you want to delete ${deletableIds.length} files?`, confirmText: "Delete All", variant: 'danger' })) return;
 
         let success = 0;
         let fail = 0;
-        for (const id of selectedIds) {
+        for (const id of deletableIds) {
             try {
                 await invoke('cmd_delete_file', { messageId: id, folderId: activeFolderId });
                 success++;
@@ -85,13 +97,18 @@ export function useFileOperations(
 
     const handleBulkMove = async (targetFolderId: number | null, onSuccess?: () => void) => {
         if (selectedIds.length === 0) return;
+        const movableIds = selectedIds.filter((id) => !isTextMessagesFile(id));
+        if (movableIds.length === 0) {
+            toast.info("Text messages are grouped for display and cannot be moved as a single file.");
+            return;
+        }
         try {
             await invoke('cmd_move_files', {
-                messageIds: selectedIds,
+                messageIds: movableIds,
                 sourceFolderId: activeFolderId,
                 targetFolderId: targetFolderId
             });
-            toast.success(`Moved ${selectedIds.length} files.`);
+            toast.success(`Moved ${movableIds.length} files.`);
             queryClient.invalidateQueries({ queryKey: ['files', activeFolderId] });
             setSelectedIds([]);
             if (onSuccess) onSuccess();

--- a/app/src/hooks/useTelegramConnection.ts
+++ b/app/src/hooks/useTelegramConnection.ts
@@ -58,7 +58,15 @@ export function useTelegramConnection(onLogoutParent: () => void) {
                         }
                     }
                 } else {
-                    onLogoutParent();
+                    try {
+                        const connected = await invoke<boolean>('cmd_check_connection');
+                        setIsConnected(connected);
+                        if (connected) {
+                            queryClient.invalidateQueries({ queryKey: ['files'] });
+                        }
+                    } catch {
+                        setIsConnected(false);
+                    }
                 }
 
             } catch {

--- a/app/src/lib/nasApi.ts
+++ b/app/src/lib/nasApi.ts
@@ -1,0 +1,81 @@
+import type {
+  AppSession,
+  AppUser,
+  AuditEntry,
+  LoginResponse,
+  MeResponse,
+  PermissionAssignment,
+  QrTokenResponse,
+  SystemStatus,
+} from "../types/nas";
+
+export const getApiBaseUrl = () => {
+  const currentHost = window.location.hostname;
+  const host =
+    !currentHost || currentHost === "tauri.localhost" || currentHost === "localhost"
+      ? "localhost"
+      : currentHost;
+  return `http://${host}:14201`;
+};
+
+const TOKEN_STORAGE_KEY = "telegram_drive_access_token";
+
+export const nasSession = {
+  getAccessToken: () => localStorage.getItem(TOKEN_STORAGE_KEY),
+  setAccessToken: (token: string) => localStorage.setItem(TOKEN_STORAGE_KEY, token),
+  clearAccessToken: () => localStorage.removeItem(TOKEN_STORAGE_KEY),
+};
+
+async function request<T>(path: string, init: RequestInit = {}, csrfToken?: string): Promise<T> {
+  const headers = new Headers(init.headers || {});
+  headers.set("Content-Type", "application/json");
+  if (csrfToken) headers.set("x-csrf-token", csrfToken);
+  const accessToken = nasSession.getAccessToken();
+  if (accessToken) headers.set("Authorization", `Bearer ${accessToken}`);
+
+  const response = await fetch(`${getApiBaseUrl()}${path}`, {
+    ...init,
+    headers,
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({ error: response.statusText }));
+    throw new Error(body.error || response.statusText);
+  }
+  return response.json() as Promise<T>;
+}
+
+export const nasApi = {
+  systemStatus: () => request<SystemStatus>("/api/system/status"),
+  bootstrap: (payload: { username: string; password: string; display_name: string }) =>
+    request<LoginResponse>("/api/admin/bootstrap", { method: "POST", body: JSON.stringify(payload) }),
+  login: (payload: { username: string; password: string }) =>
+    request<LoginResponse>("/api/auth/login", { method: "POST", body: JSON.stringify(payload) }),
+  logout: (csrfToken?: string) =>
+    request<{ ok: boolean }>("/api/auth/logout", { method: "POST", body: JSON.stringify({}) }, csrfToken),
+  me: () => request<MeResponse>("/api/auth/me"),
+  redeemQr: (token: string) => request<LoginResponse>(`/api/auth/qr/redeem/${encodeURIComponent(token)}`, { method: "POST", body: JSON.stringify({}) }),
+  listUsers: () => request<AppUser[]>("/api/admin/users"),
+  createUser: (payload: { username: string; password: string; display_name: string; disabled: boolean; role: "admin" | "user" }, csrfToken: string) =>
+    request<AppUser>("/api/admin/users", { method: "POST", body: JSON.stringify(payload) }, csrfToken),
+  updateUser: (userId: string, payload: Record<string, unknown>, csrfToken: string) =>
+    request<{ ok: boolean }>(`/api/admin/users/${userId}`, { method: "PUT", body: JSON.stringify(payload) }, csrfToken),
+  deleteUser: (userId: string, csrfToken: string) =>
+    request<{ ok: boolean }>(`/api/admin/users/${userId}`, { method: "DELETE" }, csrfToken),
+  listSessions: () => request<AppSession[]>("/api/admin/sessions"),
+  revokeSession: (sessionId: string, csrfToken: string) =>
+    request<{ ok: boolean }>(`/api/admin/sessions/${sessionId}`, { method: "DELETE" }, csrfToken),
+  generateQr: (userId: string, csrfToken: string) =>
+    request<QrTokenResponse>(`/api/admin/users/${userId}/qr`, { method: "POST", body: JSON.stringify({}) }, csrfToken),
+  revokeQr: (userId: string, csrfToken: string) =>
+    request<{ ok: boolean }>(`/api/admin/users/${userId}/qr`, { method: "DELETE" }, csrfToken),
+  getPermissions: (userId: string) =>
+    request<PermissionAssignment[]>(`/api/admin/users/${userId}/permissions`),
+  setPermissions: (userId: string, permissions: PermissionAssignment[], csrfToken: string) =>
+    request<{ ok: boolean }>(`/api/admin/users/${userId}/permissions`, { method: "PUT", body: JSON.stringify({ permissions }) }, csrfToken),
+  ownerStatus: () => request<{ configured: boolean; api_id?: string; connected: boolean }>("/api/admin/owner/status"),
+  saveOwnerConfig: (payload: { api_id: number; api_hash: string }, csrfToken: string) =>
+    request<{ ok: boolean }>("/api/admin/owner/config", { method: "POST", body: JSON.stringify(payload) }, csrfToken),
+  listAuditLogs: () => request<AuditEntry[]>("/api/admin/audit-logs"),
+};

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -5,6 +5,7 @@ export interface TelegramFile {
     sizeStr: string; // Formatted size
     created_at?: string;
     type?: 'folder' | 'file'; // implied icon_type
+    text_content?: string | null;
     // Add other fields if backend sends them
 }
 

--- a/app/src/types/nas.ts
+++ b/app/src/types/nas.ts
@@ -1,0 +1,66 @@
+export type AppRole = "admin" | "user";
+export type AccessLevel = "read_only" | "read_write";
+
+export interface SystemStatus {
+  setup_required: boolean;
+  owner_configured: boolean;
+  owner_connected: boolean;
+  api_base_url: string;
+}
+
+export interface AppUser {
+  id: string;
+  username: string;
+  display_name: string;
+  role: AppRole;
+  disabled: boolean;
+  created_at: number;
+}
+
+export interface PermissionAssignment {
+  folder_id: string;
+  folder_label: string;
+  access_level: AccessLevel;
+  is_private: boolean;
+}
+
+export interface MeResponse {
+  user: AppUser;
+  permissions: PermissionAssignment[];
+  owner_connected: boolean;
+  csrf_token: string;
+}
+
+export interface LoginResponse {
+  user: AppUser;
+  csrf_token: string;
+  access_token: string;
+}
+
+export interface AppSession {
+  id: string;
+  user_id: string;
+  username: string;
+  created_at: number;
+  expires_at: number;
+  last_seen_at: number;
+  user_agent: string;
+  ip_address: string;
+}
+
+export interface QrTokenResponse {
+  token: string;
+  login_url: string;
+  expires_at: number;
+  user_id: string;
+}
+
+export interface AuditEntry {
+  id: string;
+  actor_user_id?: string | null;
+  action: string;
+  target_type: string;
+  target_id: string;
+  metadata_json: string;
+  created_at: number;
+}

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -24,3 +24,4 @@ export const isVideoFile   = (name: string) => endsWithAny(name, VIDEO_EXTENSION
 export const isAudioFile   = (name: string) => endsWithAny(name, AUDIO_EXTENSIONS);
 export const isImageFile   = (name: string) => endsWithAny(name, IMAGE_EXTENSIONS);
 export const isPdfFile     = (name: string) => name.toLowerCase().endsWith('.pdf');
+export const isTextFile    = (name: string) => endsWithAny(name, ['txt', 'md', 'log'] as const);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Telegram-Drive",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Summary

Adds support for detecting Telegram text-only messages and showing them as `.txt` files in the file explorer.

## Changes

- Detects plain Telegram messages without media in folder listings
- Generates readable `.txt` filenames from the message text
- Adds text-message download support
- Adds text preview support for `.txt`, `.md`, and `.log` files
- Adds `text_content` metadata to file models/types

## Testing

- Ran `npm run build`
- Ran `cargo check`

## SCREENSHOT

TELEGRAM MESSAGE CHAT:
<img width="1312" height="1000" alt="image" src="https://github.com/user-attachments/assets/65f73dcd-f9a9-49cd-965f-b78195ccc8ff" />
DESKTOP APP
<img width="1663" height="945" alt="image" src="https://github.com/user-attachments/assets/85474b62-3a71-43f5-85c5-3edcde306ff1" />
POPUP FEATURE
<img width="1919" height="1005" alt="image" src="https://github.com/user-attachments/assets/8c5813fa-8d39-4e06-96fc-018ce75049db" />
