### PR TITLE
perf: lazy load PDF preview bundle

### DIFF
--- a/app/src/components/Dashboard.tsx
+++ b/app/src/components/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, lazy, Suspense } from 'react';
 import { AnimatePresence } from 'framer-motion';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { invoke } from '@tauri-apps/api/core';
@@ -18,7 +18,10 @@ import { PreviewModal } from './dashboard/PreviewModal';
 import { MediaPlayer } from './dashboard/MediaPlayer';
 import { DragDropOverlay } from './dashboard/DragDropOverlay';
 import { ExternalDropBlocker } from './dashboard/ExternalDropBlocker';
-import { PdfViewer } from './dashboard/PdfViewer';
+
+const PdfViewer = lazy(() =>
+    import('./dashboard/PdfViewer').then((module) => ({ default: module.PdfViewer }))
+);
 import { SettingsModal } from './dashboard/SettingsModal';
 
 // Hooks
@@ -367,16 +370,17 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
                     />
                 )}
                 {pdfFile && (
-                    <PdfViewer
-                        file={pdfFile}
-                        onClose={() => setPdfFile(null)}
-                        onNext={handleNextPreview}
-                        onPrev={handlePrevPreview}
-                        currentIndex={previewContextIndex}
-                        totalItems={previewContextFiles.length}
-                        activeFolderId={activeFolderId}
-                        key="pdf-viewer"
-                    />
+                    <Suspense fallback={null} key="pdf-viewer">
+                        <PdfViewer
+                            file={pdfFile}
+                            onClose={() => setPdfFile(null)}
+                            onNext={handleNextPreview}
+                            onPrev={handlePrevPreview}
+                            currentIndex={previewContextIndex}
+                            totalItems={previewContextFiles.length}
+                            activeFolderId={activeFolderId}
+                        />
+                    </Suspense>
                 )}
                 {isDragging && internalDragFileId === null && <DragDropOverlay key="drag-drop-overlay" />}
             </AnimatePresence>

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -29,4 +29,15 @@ export default defineConfig(async () => ({
       ignored: ["**/src-tauri/**"],
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes("node_modules/pdfjs-dist")) return "pdfjs";
+          if (id.includes("node_modules/lucide-react")) return "icons";
+          if (id.includes("node_modules/framer-motion")) return "motion";
+        },
+      },
+    },
+  },
 }));


### PR DESCRIPTION
## Summary
- lazy-load the PDF viewer so pdf.js is only requested when a PDF is opened
- split pdf.js, lucide icons, and framer-motion into explicit Vite chunks
- reduces the initial app bundle from about 1,016 kB to about 399 kB in the production build

## Verification
- cd app
- npm run build

Before: main JS chunk ~1,015.94 kB with a >500 kB chunk warning.
After: main JS chunk ~399.37 kB; pdfjs chunk ~468.80 kB loaded separately.