### PR TITLE
fix: handle unavailable theme storage

### DIFF
--- a/app/src/context/ThemeContext.tsx
+++ b/app/src/context/ThemeContext.tsx
@@ -10,11 +10,28 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
+function getStoredTheme(): Theme | null {
+    try {
+        const saved = localStorage.getItem('theme');
+        return saved === 'light' || saved === 'dark' ? saved : null;
+    } catch {
+        return null;
+    }
+}
+
+function persistTheme(theme: Theme) {
+    try {
+        localStorage.setItem('theme', theme);
+    } catch {
+        // Keep the in-memory theme even when storage is unavailable.
+    }
+}
+
 // Get initial theme synchronously to prevent flash
 function getInitialTheme(): Theme {
     if (typeof window !== 'undefined') {
-        const saved = localStorage.getItem('theme') as Theme;
-        if (saved === 'light' || saved === 'dark') return saved;
+        const saved = getStoredTheme();
+        if (saved) return saved;
         if (window.matchMedia('(prefers-color-scheme: light)').matches) {
             return 'light';
         }
@@ -45,7 +62,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     // Use useLayoutEffect to apply theme synchronously before paint
     useLayoutEffect(() => {
         applyTheme(theme);
-        localStorage.setItem('theme', theme);
+        persistTheme(theme);
     }, [theme]);
 
     const toggleTheme = () => {


### PR DESCRIPTION
## What changed

- Wrap theme reads from `localStorage` in a safe helper.
- Wrap theme persistence in a best-effort helper so the selected in-memory theme still applies when storage is unavailable.
- Keep the existing system-theme fallback and immediate pre-hydration theme application behavior.

## Why

`localStorage.getItem()` and `localStorage.setItem()` can throw in restricted browser/webview environments, privacy modes, or when storage is disabled. Because the theme is read during initial render/module setup, that exception can prevent the app from loading.

## Before / after

Before, unavailable storage could crash theme initialization or toggling. After, the app falls back to the system/default theme and still applies theme changes for the current session even if persistence fails.

## Verification

- `npm ci`
- `npm run build`
- `git diff --check`