### PR TITLE
fix: avoid panicking on empty search documents

### DIFF
--- a/app/src-tauri/src/commands/fs.rs
+++ b/app/src-tauri/src/commands/fs.rs
@@ -627,7 +627,7 @@ pub async fn cmd_search_global(
         for msg in msgs.messages {
             if let tl::enums::Message::Message(m) = msg {
                 if let Some(tl::enums::MessageMedia::Document(d)) = m.media {
-                    if let tl::enums::Document::Document(doc) = d.document.unwrap() {
+                    if let Some(tl::enums::Document::Document(doc)) = d.document {
                         let name = doc.attributes.iter().find_map(|a| match a {
                             tl::enums::DocumentAttribute::Filename(f) => Some(f.file_name.clone()),
                             _ => None
@@ -653,7 +653,7 @@ pub async fn cmd_search_global(
         for msg in msgs.messages {
             if let tl::enums::Message::Message(m) = msg {
                 if let Some(tl::enums::MessageMedia::Document(d)) = m.media {
-                    if let tl::enums::Document::Document(doc) = d.document.unwrap() {
+                    if let Some(tl::enums::Document::Document(doc)) = d.document {
                         let name = doc.attributes.iter().find_map(|a| match a {
                             tl::enums::DocumentAttribute::Filename(f) => Some(f.file_name.clone()),
                             _ => None


### PR DESCRIPTION
## Problem
`cmd_search_global` handles Telegram global-search results by matching `MessageMedia::Document`, then immediately calling `d.document.unwrap()` in both `Messages` and `Slice` response branches.

If Telegram returns an empty/missing document payload for that media wrapper, the search command can panic instead of skipping that item and returning the rest of the results.

## Before
The command unwrapped `d.document` directly in both result branches.

## After
The command now only builds `FileMetadata` when `d.document` is present and is a real `Document` variant. Empty or unsupported document payloads are skipped, matching the existing behavior for non-document messages.

## Verification
- `git diff --check`

I could not run `cargo check` locally because `cargo` is not installed/on PATH in this environment.