### PR TITLE
fix: validate persisted streaming settings

### DIFF
--- a/app/src/hooks/useStreamingSettings.ts
+++ b/app/src/hooks/useStreamingSettings.ts
@@ -13,11 +13,17 @@ function loadSettings(): StreamingSettings {
         const raw = localStorage.getItem(STORAGE_KEY);
         if (raw) {
             const parsed = JSON.parse(raw);
+            if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+                return { ...DEFAULTS };
+            }
+
             // Validate quality
             const validQualities: StreamingQuality[] = ['360p', '480p', '720p', '1080p', 'original'];
-            if (!validQualities.includes(parsed.quality)) parsed.quality = DEFAULTS.quality;
-            if (typeof parsed.adaptiveMode !== 'boolean') parsed.adaptiveMode = DEFAULTS.adaptiveMode;
-            return { ...DEFAULTS, ...parsed };
+            const quality = validQualities.includes(parsed.quality) ? parsed.quality : DEFAULTS.quality;
+            const adaptiveMode =
+                typeof parsed.adaptiveMode === 'boolean' ? parsed.adaptiveMode : DEFAULTS.adaptiveMode;
+
+            return { quality, adaptiveMode };
         }
     } catch { /* corrupt data, use defaults */ }
     return { ...DEFAULTS };


### PR DESCRIPTION
## Problem

`useStreamingSettings` trusts the value loaded from `localStorage` after `JSON.parse()`. If that stored value is a JSON string, array, or another non-settings shape, the hook can merge unexpected keys into the settings object or mutate the parsed object while normalizing fields.

## Before / After

Before, any parsed object-like value was spread into the returned settings, and validation happened by mutating `parsed`.

After, persisted settings must be a plain object shape, arrays and primitive values fall back to defaults, and the hook returns only the known `quality` and `adaptiveMode` fields.

## Verification

- `npm ci`
- `npm run build`

The build completed successfully. Vite reported existing chunk-size/dynamic-import warnings only.