### PR TITLE
Fix shift-click range selection using wrong file order

### DIFF
--- a/app/src/components/desktop/DesktopDashboard.tsx
+++ b/app/src/components/desktop/DesktopDashboard.tsx
@@ -268,15 +268,17 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
         setSelectedIds([]);
     }, []);
 
-    const handleFileClick = (e: React.MouseEvent, id: number) => {
+    const handleFileClick = (e: React.MouseEvent, id: number, orderedFiles: TelegramFile[]) => {
         e.stopPropagation();
-        const currentIndex = displayedFiles.findIndex(f => f.id === id);
+        const currentIndex = orderedFiles.findIndex(f => f.id === id);
 
         if (e.shiftKey && lastClickedIndexRef.current >= 0) {
-            // Shift+Click: range select from last clicked to current
+            // Shift+Click: range select from last clicked to current.
+            // Must use the same (sorted) order the grid renders, not displayedFiles,
+            // otherwise the range mismatches what's visually between the two clicks.
             const start = Math.min(lastClickedIndexRef.current, currentIndex);
             const end = Math.max(lastClickedIndexRef.current, currentIndex);
-            const rangeIds = displayedFiles.slice(start, end + 1).map(f => f.id);
+            const rangeIds = orderedFiles.slice(start, end + 1).map(f => f.id);
             setSelectedIds(rangeIds);
         } else if (e.metaKey || e.ctrlKey) {
             // Ctrl/Cmd+Click: toggle individual file

--- a/app/src/components/desktop/dashboard/FileExplorer.tsx
+++ b/app/src/components/desktop/dashboard/FileExplorer.tsx
@@ -19,7 +19,7 @@ interface FileExplorerProps {
     viewMode: 'grid' | 'list';
     selectedIds: number[];
     activeFolderId: number | null;
-    onFileClick: (e: React.MouseEvent, id: number) => void;
+    onFileClick: (e: React.MouseEvent, id: number, orderedFiles: TelegramFile[]) => void;
     onDelete: (id: number) => void;
     onDownload: (id: number, name: string) => void;
     onPreview: (file: TelegramFile, orderedFiles?: TelegramFile[]) => void;
@@ -317,7 +317,7 @@ export function FileExplorer({
                                                 key={file.id}
                                                 file={file}
                                                 isSelected={selectedIds.includes(file.id)}
-                                                onClick={(e) => onFileClick(e, file.id)}
+                                                onClick={(e) => onFileClick(e, file.id, sortedFiles)}
                                                 onContextMenu={(e) => handleContextMenu(e, file)}
                                                 onDelete={() => onDelete(file.id)}
                                                 onDownload={() => onDownload(file.id, file.name)}
@@ -404,7 +404,7 @@ export function FileExplorer({
                                     <FileListItem
                                         file={file}
                                         selectedIds={selectedIds}
-                                        onFileClick={onFileClick}
+                                        onFileClick={(e, id) => onFileClick(e, id, sortedFiles)}
                                         handleContextMenu={handleContextMenu}
                                         onDragStart={onDragStart}
                                         onDragEnd={onDragEnd}
@@ -433,7 +433,7 @@ export function FileExplorer({
                     }}
                     onPreview={() => {
                         if (contextMenu.file.type === 'folder') {
-                            onFileClick({ preventDefault: () => { }, stopPropagation: () => { } } as React.MouseEvent, contextMenu.file.id);
+                            onFileClick({ preventDefault: () => { }, stopPropagation: () => { } } as React.MouseEvent, contextMenu.file.id, sortedFiles);
                         } else {
                             handlePreviewRequest(contextMenu.file);
                         }


### PR DESCRIPTION
## Summary
- Fixes bug 5 reported in #139: shift-click range selection "triggers, but it ends up selecting the wrong range of items."
- Root cause: `handleFileClick` in `DesktopDashboard.tsx` computed the click index and range slice against `displayedFiles` (unsorted, raw backend order), while the grid actually renders `FileExplorer`'s locally-sorted `sortedFiles`. Whenever the user changed sort (e.g. by date, descending), the two orders diverged, so the selected range no longer matched what was visually between the two clicked items.
- Fix: thread the rendered `sortedFiles` array up through `onFileClick` (mirroring the existing pattern already used for `onPreview`), and compute the click index / range slice against that instead of `displayedFiles`.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run build` succeeds
- [ ] Manual: sort the file grid by Date (descending), shift-click two files, confirm the selected range matches the visually highlighted rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)