### PR TITLE
Fix stale MSE error overlay and oversized video icon overlap

### DIFF
--- a/app/src/components/desktop/dashboard/AdaptiveMediaPlayer.tsx
+++ b/app/src/components/desktop/dashboard/AdaptiveMediaPlayer.tsx
@@ -192,6 +192,11 @@ export function AdaptiveMediaPlayer({
         abort: abortMse,
     } = useAdaptiveStreaming(restartStreamUrl, file.name, progressiveCallback);
 
+    // Tracks a failure in the native <video> fallback itself (distinct from
+    // the MSE pipeline's own error, which becomes stale once useFallback
+    // switches playback over to this element).
+    const [fallbackError, setFallbackError] = useState<string | null>(null);
+
     // ── HLS transcode state ──────────────────────────────────────────
     // playbackMode is the single source of truth: 'original' or 'hls'
     const [playbackMode, setPlaybackMode] = useState<'original' | 'hls'>('original');
@@ -383,6 +388,7 @@ export function AdaptiveMediaPlayer({
         setFmp4Remuxing(false);
         setFmp4RemuxError(null);
         setFmp4StreamUrl(null);
+        setFallbackError(null);
         fmp4RemuxingRef.current = false;
         remuxGenerationRef.current += 1;
     }, [streamUrl]);
@@ -811,7 +817,14 @@ export function AdaptiveMediaPlayer({
     const isMseLoading = msePhase === 'loading' || msePhase === 'initializing';
     const isHlsLoading = hlsPhase === 'preparing' || hlsPhase === 'caching' || hlsPhase === 'transcoding';
     const displayPhase: string = isHlsMode ? hlsPhase : (isMseLoading ? 'loading' : msePhase);
-    const displayError: string | null = isHlsMode ? hlsError : mseError;
+    // Once the MSE pipeline hands off to the native <video> fallback, its
+    // 'error' phase is stale (that's what triggered the handoff) — the
+    // fallback is a separate playback path with its own pass/fail outcome,
+    // tracked by fallbackError instead.
+    const showError = isHlsMode
+        ? (displayPhase === 'error' || displayPhase === 'failed')
+        : (useFallback ? !!fallbackError : (displayPhase === 'error' || displayPhase === 'failed'));
+    const displayError: string | null = isHlsMode ? hlsError : (useFallback ? fallbackError : mseError);
     const showOriginalVideo = !isHlsMode && !useFallback;
 
     // Build the effective quality label
@@ -875,7 +888,7 @@ export function AdaptiveMediaPlayer({
                     )}
 
                     {/* Error display */}
-                    {(displayPhase === 'error' || displayPhase === 'failed') && (
+                    {showError && (
                         <div className="flex flex-col items-center gap-3 text-white px-8">
                             <AlertTriangle className="w-10 h-10 text-red-400" />
                             <p className="text-sm text-red-400 font-medium">Playback Error</p>
@@ -943,7 +956,14 @@ export function AdaptiveMediaPlayer({
 
                     {/* Fallback: native <video> (non-MP4 or no MSE support) */}
                     {useFallback && !isHlsMode && (
-                        <video src={fallbackUrl} controls controlsList="nodownload" autoPlay className="w-full h-full object-contain" />
+                        <video
+                            src={fallbackUrl}
+                            controls
+                            controlsList="nodownload"
+                            autoPlay
+                            className="w-full h-full object-contain"
+                            onError={(e) => setFallbackError(e.currentTarget.error?.message || 'Native video playback failed')}
+                        />
                     )}
 
                     {/* HLS video element — rendered as soon as HLS mode is active so attachMedia works */}
@@ -1044,7 +1064,7 @@ export function AdaptiveMediaPlayer({
                 )}
 
                 {/* Fullscreen overlay toolbar */}
-                {isFullscreen && (displayPhase !== 'error' && displayPhase !== 'failed') && (
+                {isFullscreen && !showError && (
                     <div className="absolute bottom-0 left-0 right-0 z-30 bg-gradient-to-t from-black/90 via-black/60 to-transparent p-4 pt-12 pointer-events-none">
                         <div className="flex items-center justify-between pointer-events-auto">
                             <div className="flex items-center gap-3">

--- a/app/src/components/desktop/dashboard/FileCard.tsx
+++ b/app/src/components/desktop/dashboard/FileCard.tsx
@@ -139,7 +139,11 @@ export function FileCard({ file, onDelete, onDownload, onPreview, onShare, isSel
                         <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
                     </div>
                 ) : (
-                    <div className="absolute inset-0 flex items-center justify-center p-4">
+                    // Reserve space for the file-info overlay below (name + size/badges)
+                    // so the centered icon doesn't visually collide with that text on
+                    // shorter cards — most noticeable with video files, whose metadata
+                    // badge makes that overlay taller than other file types'.
+                    <div className="absolute top-0 left-0 right-0 bottom-16 flex items-center justify-center p-4">
                         {isFolder ? (
                             <Folder className="w-12 h-12 text-telegram-primary" />
                         ) : thumbnailLoading && isImageFile(file.name) ? (


### PR DESCRIPTION
## Summary
Addresses the remaining reproducible bugs from #139 that weren't covered by PR #141 (shift-click range selection).

**Bug 2 — video playback error ("Invalid data found while parsing box")**
Root cause: `AdaptiveMediaPlayer`'s error overlay and fullscreen toolbar visibility were driven directly by `displayPhase` (== the MSE hook's internal phase). When the MSE/mp4box pipeline hits an error — including mp4box's own `"Invalid data found while parsing box"` — and hands off to the native `<video>` fallback (`useFallback`), the MSE hook's initialization effect never runs again, so `displayPhase` stays stuck at `'error'` indefinitely even though the fallback is now the active, potentially-working playback path. Users saw a scary "Playback Error" banner rendered alongside (or in front of) a native `<video>` element that may well have been playing fine.

Fix: once `useFallback` is active, stop reading the stale MSE phase/error for display purposes. Track the fallback `<video>`'s own success/failure via its `onError` event instead, and only surface an error banner for whichever playback path (MSE or native fallback) is actually in use. This also fixes the fullscreen toolbar controls staying permanently hidden after any MSE error, even once the fallback was playing.

**Bug 3 — oversized video icon overlapping file name/metadata**
Root cause: in `FileCard`'s grid view, the fallback file-type icon container used `absolute inset-0` (spanning the *entire* card) with the icon centered inside it, while the file name/size/metadata overlay is separately pinned to the bottom via `absolute bottom-0`. On shorter cards, the centered icon's bounding area overlapped the text overlay — most visible for videos, since their metadata badge (duration/resolution) makes that bottom overlay taller than for other file types, increasing the overlap.

Fix: reserve space at the bottom of the icon container (`bottom-16` instead of full `inset-0`) so it never renders into the zone reserved for the info overlay.

**Bug 1 (8k+ file loading loop)** — already fixed by 84b02c2 (chunked folder loading with an infinite-loop guard); no change needed, verified via `git log`/diff.
**Bug 5 (shift-click range selection)** — already fixed in #141.

Not addressed here (feature requests, not bugs, and out of scope for this fix): thumbnail generation for video/PDF files, double-click-to-open, and marquee/rectangle selection — each would need new dependencies (e.g. video frame extraction, PDF rendering) or substantial new interaction code.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run build` succeeds
- [ ] Manual: trigger an MSE playback error (e.g. a moov-at-end MP4 that fails extraction) and confirm the native fallback plays without a lingering error banner
- [ ] Manual: shrink the grid card size (zoom out) and confirm the file icon no longer overlaps the name/metadata text, especially for video files

🤖 Generated with [Claude Code](https://claude.com/claude-code)