### PR TITLE
Fix Android launch crash

### DIFF
--- a/app/scripts/check-android-cxx-runtime.ps1
+++ b/app/scripts/check-android-cxx-runtime.ps1
@@ -1,0 +1,41 @@
+param(
+    [Parameter(Mandatory)]
+    [ValidateScript({ Test-Path -LiteralPath $_ -PathType Leaf })]
+    [string]$ApkPath
+)
+
+$ErrorActionPreference = 'Stop'
+$readElf = Get-ChildItem (Join-Path $env:LOCALAPPDATA 'Android\Sdk\ndk') `
+    -Filter llvm-readelf.exe -Recurse |
+    Sort-Object FullName -Descending |
+    Select-Object -First 1 -ExpandProperty FullName
+
+if (-not $readElf) {
+    throw 'llvm-readelf.exe was not found in the Android NDK.'
+}
+
+$workDir = Join-Path ([System.IO.Path]::GetTempPath()) ('telegram-drive-elf-' + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $workDir | Out-Null
+
+try {
+    tar -xf $ApkPath -C $workDir 'lib/arm64-v8a/libapp_lib.so'
+    if ($LASTEXITCODE -ne 0) {
+        throw 'The APK does not contain lib/arm64-v8a/libapp_lib.so.'
+    }
+
+    $library = Join-Path $workDir 'lib\arm64-v8a\libapp_lib.so'
+    $symbols = & $readElf -Ws $library
+    $needed = & $readElf -d $library
+    if ($LASTEXITCODE -ne 0) {
+        throw 'llvm-readelf could not inspect libapp_lib.so.'
+    }
+
+    if ($symbols -match 'UND _ZTISt12length_error' -and
+        $needed -notmatch 'Shared library: \[libc\+\+_shared\.so\]') {
+        throw 'libapp_lib.so uses the C++ runtime without declaring libc++_shared.so.'
+    }
+} finally {
+    Remove-Item -LiteralPath $workDir -Recurse -Force
+}
+
+Write-Host 'PASS: libapp_lib.so has no unresolved C++ runtime dependency.'

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
  "flate2",
  "foldhash 0.1.5",
  "futures-core",
- "h2 0.3.27",
+ "h2",
  "http 0.2.12",
  "httparse",
  "httpdate",
@@ -1204,16 +1204,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1235,9 +1225,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -1248,7 +1238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation 0.10.1",
+ "core-foundation",
  "libc",
 ]
 
@@ -1960,21 +1950,12 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -1987,12 +1968,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2573,25 +2548,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http 1.4.1",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2817,7 +2773,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
  "http 1.4.1",
  "http-body",
  "httparse",
@@ -2845,22 +2800,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2878,11 +2817,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.4",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -3613,23 +3550,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4006,47 +3926,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -4763,21 +4646,16 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.14",
  "http 1.4.1",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4788,7 +4666,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -4967,7 +4844,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni 0.22.4",
  "log",
@@ -5094,7 +4971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5677,27 +5554,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5724,7 +5580,7 @@ checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.10.0",
  "block2",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -6398,16 +6254,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6871,12 +6717,6 @@ name = "v_htmlescape"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e8257fbc510f0a46eb602c10215901938b5c2a7d5e70fc11483b1d3c9b5b18c"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -62,18 +62,20 @@ hmac = "0.12"
 zeroize = { version = "1", features = ["derive"] }
 getrandom = "0.2"
 zip = { version = "2", default-features = false, features = ["deflate"] }
-unrar = "0.5"
 sevenz-rust2 = "0.7"
 path-clean = "1"
 walkdir = "2"
 sqlite = { version = "0.37.0", features = ["bundled"] }
 mp4parse = "0.17"
 urlencoding = "2"
-reqwest = { version = "0.12", features = ["stream", "rustls-tls", "socks"] }
+reqwest = { version = "0.12", default-features = false, features = ["stream", "rustls-tls", "socks"] }
 sysinfo = "0.30"
 tokio-rustls = "0.26"
 rustls = "0.23"
 webpki-roots = "0.26"
+
+[target.'cfg(not(target_os = "android"))'.dependencies]
+unrar = "0.5"
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.21"

--- a/app/src-tauri/src/commands/archive.rs
+++ b/app/src-tauri/src/commands/archive.rs
@@ -64,7 +64,10 @@ pub async fn cmd_list_archive_contents(
 
     match archive_type {
         ArchiveType::Zip => list_zip_contents(&client, &media, max_bytes, &filename).await,
+        #[cfg(not(target_os = "android"))]
         ArchiveType::Rar => list_rar_contents(&client, &media, max_bytes, &filename).await,
+        #[cfg(target_os = "android")]
+        ArchiveType::Rar => Err("RAR archives are not supported on Android".to_string()),
         ArchiveType::SevenZ => list_sevenz_contents(&client, &media, max_bytes, &filename).await,
     }
 }
@@ -85,7 +88,10 @@ pub async fn cmd_extract_archive_entry(
 
     match archive_type {
         ArchiveType::Zip => extract_zip_entry(&client, &media, max_bytes, entry_index).await,
+        #[cfg(not(target_os = "android"))]
         ArchiveType::Rar => extract_rar_entry(&client, &media, max_bytes, entry_index).await,
+        #[cfg(target_os = "android")]
+        ArchiveType::Rar => Err("RAR archives are not supported on Android".to_string()),
         ArchiveType::SevenZ => extract_sevenz_entry(&client, &media, max_bytes, entry_index).await,
     }
 }
@@ -283,6 +289,7 @@ async fn download_to_temp_file(
     Ok((archive_path, extract_dir))
 }
 
+#[cfg(not(target_os = "android"))]
 async fn list_rar_contents(
     client: &grammers_client::Client,
     media: &Media,
@@ -323,6 +330,7 @@ async fn list_rar_contents(
     Ok(entries)
 }
 
+#[cfg(not(target_os = "android"))]
 async fn extract_rar_entry(
     client: &grammers_client::Client,
     media: &Media,

--- a/app/src-tauri/src/commands/fs.rs
+++ b/app/src-tauri/src/commands/fs.rs
@@ -968,8 +968,13 @@ fn publish_verified_android_download(
         ],
     );
     match result {
-        Ok(value) if value.z().unwrap_or(false) => Ok(()),
-        Ok(_) => Err("Android MediaStore rejected the verified file".to_string()),
+        Ok(value) => {
+            if value.z().unwrap_or(false) {
+                Ok(())
+            } else {
+                Err("Android MediaStore rejected the verified file".to_string())
+            }
+        }
         Err(error) => {
             if env.exception_check().unwrap_or(false) {
                 let _ = env.exception_describe();


### PR DESCRIPTION
## Summary

- exclude the native `unrar` dependency and RAR handlers from Android builds
- return a clear unsupported-format error for RAR operations on Android while preserving desktop support
- disable `reqwest` default TLS features so Android uses the configured Rustls stack only
- fix Android JNI boolean handling that otherwise moved the return value in a match guard
- add an APK regression check for unresolved C++ runtime dependencies

## Root cause

The published arm64 APK pulled `unrar_sys` C++ code into `libapp_lib.so`, but the library did not declare `libc++_shared.so` as a needed dependency. Android therefore aborted startup with:

```text
java.lang.UnsatisfiedLinkError: cannot locate symbol "_ZTISt12length_error"
referenced by libapp_lib.so
```

`unrar_sys` is not Android-compatible in a clean cross-compilation, so this change excludes native RAR support on Android instead of adding a fragile runtime-loader workaround.

## Impact

The Android app launches normally. RAR listing and extraction now return `RAR archives are not supported on Android`; ZIP and 7z behavior is unchanged, and desktop RAR support remains available.

## Validation

- `npm run build`
- `cargo test --lib` in the VS 2019 developer environment: 23 passed
- `npm run tauri android build -- --debug -t aarch64 --apk true --aab false --ci`
- regression script rejects released APK SHA-256 `DB73F24A23E72B3A45D2AEA1B7F34DB7778648F6AC13E31062385109AEE7D875`
- regression script passes fixed APK SHA-256 `44451500427B7BE1E120B751C43EA8F58D8BFD8911452E0A5E955BB30E089257`
- Pixel 7 Pro (`29221FDH300MLF`, Android 17/API 37): three cold launches produced live PIDs, foreground `MainActivity`, and empty crash buffers; the Telegram Drive configuration screen rendered after dismissing Android's debug-only compatibility dialog

## Follow-up

Android 17 still reports the existing 16 KB LOAD-segment alignment warning for this debug artifact. That packaging issue is separate from the resolved startup crash and is not changed here.
