### PR TITLE
Harden ad link fallback window.open calls

### DIFF
--- a/app/src/components/desktop/dashboard/DesktopAdBanner.tsx
+++ b/app/src/components/desktop/dashboard/DesktopAdBanner.tsx
@@ -114,7 +114,7 @@ export function DesktopAdBanner() {
     try {
       await open(AD_CLICK_URL);
     } catch {
-      window.open(AD_CLICK_URL, '_blank');
+      window.open(AD_CLICK_URL, '_blank', 'noopener,noreferrer');
     }
   }, []);
 

--- a/app/src/components/shared/AdsterraBanner.tsx
+++ b/app/src/components/shared/AdsterraBanner.tsx
@@ -37,7 +37,7 @@ export default function AdsterraBanner({ visible }: AdsterraBannerProps) {
     try {
       await open(SMARTLINK_URL);
     } catch {
-      window.open(SMARTLINK_URL, '_blank');
+      window.open(SMARTLINK_URL, '_blank', 'noopener,noreferrer');
     }
   }, []);
 


### PR DESCRIPTION
## Problem

The ad click fallback path uses `window.open(..., '_blank')` when the Tauri `open()` helper is unavailable or throws. In browser contexts, opening a new tab without `noopener` can leave the opened page with access to `window.opener`.

## Before / after

Before, the fallback calls opened the ad destination in a new tab without explicitly isolating the opener context.

After, both fallback calls pass `noopener,noreferrer`, matching the safer pattern for external `_blank` links while keeping the existing Tauri-first behavior unchanged.

## Verification

- `npm ci`
- `npm run build`