### PR TITLE
Harden ad link fallback window.open calls

### DIFF
--- a/app/src/components/desktop/dashboard/DesktopAdBanner.tsx
+++ b/app/src/components/desktop/dashboard/DesktopAdBanner.tsx
@@ -114,7 +114,7 @@ export function DesktopAdBanner() {
     try {
       await open(AD_CLICK_URL);
     } catch {
-      window.open(AD_CLICK_URL, '_blank');
+      window.open(AD_CLICK_URL, '_blank', 'noopener,noreferrer');
     }
   }, []);
 

--- a/app/src/components/shared/AdsterraBanner.tsx
+++ b/app/src/components/shared/AdsterraBanner.tsx
@@ -37,7 +37,7 @@ export default function AdsterraBanner({ visible }: AdsterraBannerProps) {
     try {
       await open(SMARTLINK_URL);
     } catch {
-      window.open(SMARTLINK_URL, '_blank');
+      window.open(SMARTLINK_URL, '_blank', 'noopener,noreferrer');
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- add noopener,noreferrer to the desktop ad fallback
- add noopener,noreferrer to the shared Adsterra fallback
- leave native Tauri open calls unchanged

## Verification
- audited all window.open calls under app/src
- npm run build