### PR TITLE
fix: tolerate unavailable update storage

### DIFF
--- a/app/src/services/updateReliability.ts
+++ b/app/src/services/updateReliability.ts
@@ -19,6 +19,30 @@ interface PendingUpdate {
     createdAt: string;
 }
 
+function readLocalStorage(key: string): string | null {
+    try {
+        return localStorage.getItem(key);
+    } catch {
+        return null;
+    }
+}
+
+function writeLocalStorage(key: string, value: string): void {
+    try {
+        localStorage.setItem(key, value);
+    } catch {
+        // Storage can be unavailable in private browsing or locked-down shells.
+    }
+}
+
+function removeLocalStorage(key: string): void {
+    try {
+        localStorage.removeItem(key);
+    } catch {
+        // Best-effort cleanup should not mask the original update error.
+    }
+}
+
 function writePendingUpdate(update: Update): void {
     const pending: PendingUpdate = {
         fromVersion: update.currentVersion,
@@ -26,7 +50,7 @@ function writePendingUpdate(update: Update): void {
         body: update.body,
         createdAt: new Date().toISOString(),
     };
-    localStorage.setItem(PENDING_UPDATE_KEY, JSON.stringify(pending));
+    writeLocalStorage(PENDING_UPDATE_KEY, JSON.stringify(pending));
 }
 
 export async function installVerifiedUpdate(
@@ -72,25 +96,25 @@ export async function installVerifiedUpdate(
         await update.install();
         await relaunch();
     } catch (error) {
-        localStorage.removeItem(PENDING_UPDATE_KEY);
+        removeLocalStorage(PENDING_UPDATE_KEY);
         throw error;
     }
 }
 
 export function consumeWhatsNew(currentVersion: string): WhatsNewDetails | null {
-    const lastSeenVersion = localStorage.getItem(LAST_SEEN_VERSION_KEY);
-    localStorage.setItem(LAST_SEEN_VERSION_KEY, currentVersion);
+    const lastSeenVersion = readLocalStorage(LAST_SEEN_VERSION_KEY);
+    writeLocalStorage(LAST_SEEN_VERSION_KEY, currentVersion);
 
-    const rawPending = localStorage.getItem(PENDING_UPDATE_KEY);
+    const rawPending = readLocalStorage(PENDING_UPDATE_KEY);
     if (rawPending) {
         try {
             const pending = JSON.parse(rawPending) as PendingUpdate;
             if (pending.toVersion === currentVersion) {
-                localStorage.removeItem(PENDING_UPDATE_KEY);
+                removeLocalStorage(PENDING_UPDATE_KEY);
                 return { version: currentVersion, body: pending.body, updated: true };
             }
         } catch {
-            localStorage.removeItem(PENDING_UPDATE_KEY);
+            removeLocalStorage(PENDING_UPDATE_KEY);
         }
     }
 

--- a/app/tests/unit/updateReliability.test.ts
+++ b/app/tests/unit/updateReliability.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { consumeWhatsNew } from '../../src/services/updateReliability';
+
+describe('consumeWhatsNew', () => {
+  it('does not throw when localStorage is unavailable', () => {
+    const originalLocalStorage = window.localStorage;
+    const unavailableStorage = {
+      getItem: () => {
+        throw new Error('storage unavailable');
+      },
+      setItem: () => {
+        throw new Error('storage unavailable');
+      },
+      removeItem: () => {
+        throw new Error('storage unavailable');
+      },
+      clear: () => {},
+    };
+
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: unavailableStorage,
+    });
+
+    try {
+      expect(() => consumeWhatsNew('2.3.0')).not.toThrow();
+      expect(consumeWhatsNew('2.3.0')).toBeNull();
+    } finally {
+      Object.defineProperty(window, 'localStorage', {
+        configurable: true,
+        value: originalLocalStorage,
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`consumeWhatsNew()` runs during app startup and the update install path also records pending update metadata. Both paths used `localStorage` directly. If storage is unavailable or throws in a locked-down/private browsing shell, the app can fail during startup or mask the original update install error while trying to clean up pending update state.

## Before / after

Before, `localStorage.getItem`, `setItem`, and `removeItem` exceptions propagated from the update reliability helpers.

After, update metadata persistence is best-effort: unavailable storage no longer prevents startup, and cleanup during install failure cannot hide the original install error.

## Verification

- `npm test -- updateReliability`
- `npm run build`
- `git diff --check`